### PR TITLE
Move ADMM/IRL1 loop allocations outside hot loop

### DIFF
--- a/internal/tomo/admm.go
+++ b/internal/tomo/admm.go
@@ -77,6 +77,7 @@ func (s *ADMMSolver) Solve(p *Problem) (*Solution, error) {
 	u := mat.NewVecDense(n, nil)
 
 	rhs := mat.NewVecDense(n, nil)
+	zOld := mat.NewVecDense(n, nil)
 	iters := 0
 
 	for k := 0; k < maxIter; k++ {
@@ -92,7 +93,6 @@ func (s *ADMMSolver) Solve(p *Problem) (*Solution, error) {
 
 		// z-update: z = soft_threshold(x + u, λ/ρ)
 		kappa := lambda / rho
-		zOld := mat.NewVecDense(n, nil)
 		zOld.CopyVec(z)
 		for i := 0; i < n; i++ {
 			v := x.AtVec(i) + u.AtVec(i)

--- a/internal/tomo/irl1.go
+++ b/internal/tomo/irl1.go
@@ -85,6 +85,7 @@ func (s *IRL1Solver) Solve(p *Problem) (*Solution, error) {
 	u := mat.NewVecDense(n, nil)
 	rhsVec := mat.NewVecDense(n, nil)
 
+	zOld := mat.NewVecDense(n, nil)
 	totalIters := 0
 	for outer := 0; outer < outerIter; outer++ {
 		for k := 0; k < innerIter; k++ {
@@ -97,7 +98,6 @@ func (s *IRL1Solver) Solve(p *Problem) (*Solution, error) {
 				return nil, fmt.Errorf("irl1: solve failed: %w", err)
 			}
 			// z-update: weighted soft-threshold
-			zOld := mat.NewVecDense(n, nil)
 			zOld.CopyVec(z)
 			for i := 0; i < n; i++ {
 				v := x.AtVec(i) + u.AtVec(i)


### PR DESCRIPTION
Closes #20

Move `mat.NewVecDense` before iteration loop, reuse via `CopyVec`.
Eliminates 200+ heap allocations per ADMM/IRL1 solve.