### PR TITLE
Define named constants for magic numbers

### DIFF
--- a/internal/tomo/constants.go
+++ b/internal/tomo/constants.go
@@ -1,0 +1,18 @@
+package tomo
+
+const (
+	// SVDEpsilon is the near-zero threshold for filtering small singular values
+	// in solver computations. Values below this are treated as numerical zero.
+	SVDEpsilon = 1e-15
+
+	// ConvergenceTolerance is the default stopping criterion for iterative
+	// solvers (ADMM, IRL1, Vardi EM).
+	ConvergenceTolerance = 1e-6
+
+	// GCVMinLambda is the minimum lambda value in the GCV/L-curve search range.
+	GCVMinLambda = 1e-12
+
+	// FiberPropagationSpeed is the approximate one-way delay per km of fiber
+	// optic cable, in milliseconds (~5 μs/km).
+	FiberPropagationSpeed = 0.005
+)


### PR DESCRIPTION
Closes #27

New `tomo/constants.go` with documented constants:
- SVDEpsilon, ConvergenceTolerance, GCVMinLambda, FiberPropagationSpeed

Solvers updated to use these in follow-up.