### PR TITLE
Trigger CI on dev branch, fix race detector timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   test:
@@ -25,7 +25,10 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test -race -v ./...
+        run: go test -v -timeout=300s ./...
+
+      - name: Test (race detector, short mode)
+        run: go test -race -short -timeout=300s ./...
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes
- CI triggers on push/PR to both `main` and `dev`
- Regular tests: full suite, 300s timeout
- Race detector: `-short` mode (skips stress tests), 300s timeout

## Why
- PRs to dev had no CI checks
- Race detector on full suite exceeded 600s timeout (8 solvers in benchmark + stress tests)
- `-short` mode skips `testing.Short()` guarded stress tests while still catching race conditions