### PR TITLE
Make TUI and ICMP probing optional via build tags

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,7 +29,9 @@ Feed it traceroutes. See the invisible.`,
 	root.AddCommand(newBenchmarkCmd())
 	root.AddCommand(newScanCmd())
 	root.AddCommand(newPlanCmd())
-	root.AddCommand(newTUICmd())
+	if cmd := newTUICmd(); cmd != nil {
+		root.AddCommand(cmd)
+	}
 	root.AddCommand(newCompletionCmd())
 
 	return root

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -1,3 +1,5 @@
+//go:build tui
+
 package cli
 
 import (

--- a/internal/cli/tui_stub.go
+++ b/internal/cli/tui_stub.go
@@ -1,0 +1,7 @@
+//go:build !tui
+
+package cli
+
+import "github.com/spf13/cobra"
+
+func newTUICmd() *cobra.Command { return nil }

--- a/internal/measure/adapter_test.go
+++ b/internal/measure/adapter_test.go
@@ -1,3 +1,5 @@
+//go:build probing
+
 package measure
 
 import (

--- a/internal/measure/ping.go
+++ b/internal/measure/ping.go
@@ -1,3 +1,5 @@
+//go:build probing
+
 package measure
 
 import (

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,3 +1,5 @@
+//go:build tui
+
 package tui
 
 import (

--- a/internal/tui/panels/heatmap.go
+++ b/internal/tui/panels/heatmap.go
@@ -1,3 +1,5 @@
+//go:build tui
+
 package panels
 
 import (

--- a/internal/tui/panels/results.go
+++ b/internal/tui/panels/results.go
@@ -1,3 +1,5 @@
+//go:build tui
+
 package panels
 
 import (

--- a/internal/tui/panels/statusbar.go
+++ b/internal/tui/panels/statusbar.go
@@ -1,3 +1,5 @@
+//go:build tui
+
 package panels
 
 import (

--- a/internal/tui/panels/topology.go
+++ b/internal/tui/panels/topology.go
@@ -1,3 +1,5 @@
+//go:build tui
+
 package panels
 
 import (

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -1,3 +1,5 @@
+//go:build tui
+
 package styles
 
 import "github.com/charmbracelet/lipgloss"


### PR DESCRIPTION
Closes #21, #22

- `//go:build tui` on TUI files, stub returns nil without tag
- `//go:build probing` on ping.go + its tests
- Default build excludes charmbracelet + pro-bing deps
- `go build -tags "tui probing"` for full feature set