### PR TITLE
Add package godoc and update docs for public imports

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,11 @@
 # netlens Go Library API Reference
 
-Import path: `github.com/Darkroom4364/netlens/internal/...`
+```go
+import (
+    "github.com/Darkroom4364/netlens/tomo"
+    "github.com/Darkroom4364/netlens/topology"
+)
+```
 
 ## Quick Example
 
@@ -12,8 +17,8 @@ import (
     "os"
 
     "github.com/Darkroom4364/netlens/internal/format"
-    "github.com/Darkroom4364/netlens/internal/tomo"
-    "github.com/Darkroom4364/netlens/internal/topology"
+    "github.com/Darkroom4364/netlens/tomo"
+    "github.com/Darkroom4364/netlens/topology"
 )
 
 func main() {

--- a/tomo/doc.go
+++ b/tomo/doc.go
@@ -1,0 +1,16 @@
+// Package tomo provides network tomography solvers for inferring internal
+// network state from edge measurements.
+//
+// The core abstraction is the Solver interface: given a Problem (routing
+// matrix A, measurement vector b), a Solver produces a Solution (per-link
+// estimates x, confidence intervals, identifiability mask).
+//
+// Available solvers: Tikhonov, NNLS, TSVD, ADMM, IRL1, VardiEM,
+// Tomogravity, and Laplacian. Bootstrap and Conformal Prediction provide
+// uncertainty quantification.
+//
+//	import "github.com/Darkroom4364/netlens/tomo"
+//
+//	p, _ := tomo.BuildProblemFromTopology(topo, groundTruth)
+//	sol, _ := (&tomo.NNLSSolver{}).Solve(p)
+package tomo

--- a/topology/doc.go
+++ b/topology/doc.go
@@ -1,0 +1,13 @@
+// Package topology provides network graph representations and construction
+// utilities for network tomography.
+//
+// Graph is the primary type: an undirected network backed by gonum, with
+// support for loading Topology Zoo GraphML files, generating synthetic
+// topologies (Barabási-Albert, Waxman), and inferring topology from
+// traceroute measurements.
+//
+//	import "github.com/Darkroom4364/netlens/topology"
+//
+//	g, _ := topology.LoadGraphML("abilene.graphml")
+//	paths := g.AllPairsShortestPaths()
+package topology


### PR DESCRIPTION
Closes #23

- tomo/doc.go: package-level godoc with usage example
- topology/doc.go: package-level godoc with usage example
- docs/api.md: updated import paths from internal/ to public packages