### PR TITLE
Skip synthetic benchmark in race detector short mode

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -128,6 +128,9 @@ func TestCLI_BenchmarkTopologies(t *testing.T) {
 }
 
 func TestCLI_BenchmarkSynthetic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping synthetic benchmark under -short (Laplacian SVD too slow with race detector)")
+	}
 	out, err := executeCommand("benchmark", "--synthetic")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
TestCLI_BenchmarkSynthetic times out under race detector (LaplacianSolver SVD on augmented matrix). Skipped with testing.Short().