### PR TITLE
Scope CI tests by changed packages on feature branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.detect.outputs.packages }}
-      full_suite: ${{ steps.detect.outputs.full_suite }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -23,18 +22,21 @@ jobs:
         run: |
           # Full suite for: pushes to main, PRs targeting main (dev→main)
           if [[ "${{ github.base_ref }}" == "main" || "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "full_suite=true" >> "$GITHUB_OUTPUT"
             echo "packages=./..." >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-          echo "full_suite=false" >> "$GITHUB_OUTPUT"
 
           # Get changed files relative to base
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             BASE="${{ github.event.pull_request.base.sha }}"
           else
             BASE="${{ github.event.before }}"
+          fi
+
+          # First push on a new branch — no valid base to diff against
+          if [[ "$BASE" == "0000000000000000000000000000000000000000" || -z "$BASE" ]]; then
+            echo "packages=./..." >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           CHANGED=$(git diff --name-only "$BASE" HEAD -- '*.go' 'go.mod' 'go.sum')
@@ -78,6 +80,19 @@ jobs:
 
       - name: Test (race detector, short mode)
         run: go test -race -short -timeout=300s ${{ needs.changes.outputs.packages }}
+
+  test-gate:
+    name: test gate
+    needs: [changes, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pass if tests passed or were skipped
+        run: |
+          if [[ "${{ needs.test.result }}" == "success" || "${{ needs.test.result }}" == "skipped" ]]; then
+            exit 0
+          fi
+          exit 1
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,56 @@ on:
     branches: [main, dev]
 
 jobs:
+  # Detect which packages changed to scope tests on feature branches
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.detect.outputs.packages }}
+      full_suite: ${{ steps.detect.outputs.full_suite }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed packages
+        id: detect
+        run: |
+          # Full suite for: pushes to main, PRs targeting main (dev→main)
+          if [[ "${{ github.base_ref }}" == "main" || "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "full_suite=true" >> "$GITHUB_OUTPUT"
+            echo "packages=./..." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "full_suite=false" >> "$GITHUB_OUTPUT"
+
+          # Get changed files relative to base
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE" HEAD -- '*.go' 'go.mod' 'go.sum')
+
+          if [ -z "$CHANGED" ]; then
+            echo "packages=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # If go.mod/go.sum changed, run everything
+          if echo "$CHANGED" | grep -qE '^go\.(mod|sum)$'; then
+            echo "packages=./..." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Extract unique Go package directories from changed files
+          PKGS=$(echo "$CHANGED" | xargs -I{} dirname {} | sort -u | sed 's|^|./|' | paste -sd ' ' -)
+          echo "packages=$PKGS" >> "$GITHUB_OUTPUT"
+
   test:
+    needs: changes
+    if: needs.changes.outputs.packages != ''
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,10 +74,10 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test -v -timeout=300s ./...
+        run: go test -v -timeout=300s ${{ needs.changes.outputs.packages }}
 
       - name: Test (race detector, short mode)
-        run: go test -race -short -timeout=300s ./...
+        run: go test -race -short -timeout=300s ${{ needs.changes.outputs.packages }}
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `changes` job that detects which Go packages were modified
- Feature branch PRs to `dev`: only tests changed packages
- `dev → main` PRs and pushes to `main`: full `go test ./...`
- `go.mod`/`go.sum` changes trigger the full suite

Closes #74

## Test plan
- [ ] Verify feature branch PR only runs scoped tests
- [ ] Verify dev→main PR runs full suite