### PR TITLE
Fix architectural bugs found in codebase audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,19 @@ jobs:
       - name: Test (race detector, short mode)
         run: go test -race -short -timeout=300s ./...
 
+  test-gate:
+    name: test gate
+    if: always()
+    needs: [test, lint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.test.result }}" == "failure" || "${{ needs.lint.result }}" == "failure" ]]; then
+            echo "One or more required jobs failed"
+            exit 1
+          fi
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/internal/format/csv.go
+++ b/internal/format/csv.go
@@ -13,7 +13,6 @@ type CSVFormatter struct{}
 
 func (f *CSVFormatter) Format(w io.Writer, p *tomo.Problem, s *tomo.Solution) error {
 	cw := csv.NewWriter(w)
-	defer cw.Flush()
 
 	if err := cw.Write([]string{"link_id", "src", "dst", "delay_ms", "confidence_ms", "identifiable"}); err != nil {
 		return err
@@ -46,5 +45,6 @@ func (f *CSVFormatter) Format(w io.Writer, p *tomo.Problem, s *tomo.Solution) er
 		}
 	}
 
+	cw.Flush()
 	return cw.Error()
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -22,7 +22,10 @@ const (
 type tickMsg time.Time
 
 // solveResultMsg carries the result of an async solve.
-type solveResultMsg struct{ sol *tomo.Solution }
+type solveResultMsg struct {
+	sol *tomo.Solution
+	err error
+}
 
 // Model is the top-level Bubble Tea model for the netlens TUI.
 type Model struct {
@@ -40,6 +43,7 @@ type Model struct {
 	filtering   bool
 	filterText  string
 	sortMode    int
+	solveErr    string
 }
 
 // New creates a new TUI model with a list of available solvers.
@@ -140,10 +144,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				p := m.problem
 				return m, func() tea.Msg {
 					sol, err := solver.Solve(p)
-					if err != nil {
-						return nil
-					}
-					return solveResultMsg{sol}
+					return solveResultMsg{sol, err}
 				}
 			}
 		case "?":
@@ -155,8 +156,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 	case solveResultMsg:
-		if msg.sol != nil {
+		if msg.err != nil {
+			m.solveErr = msg.err.Error()
+		} else if msg.sol != nil {
 			m.solution = msg.sol
+			m.solveErr = ""
 		}
 	case tickMsg:
 		if solver := m.currentSolver(); solver != nil {
@@ -164,10 +168,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(
 				func() tea.Msg {
 					sol, err := solver.Solve(p)
-					if err != nil {
-						return nil
-					}
-					return solveResultMsg{sol}
+					return solveResultMsg{sol, err}
 				},
 				tea.Tick(m.refreshRate, func(t time.Time) tea.Msg { return tickMsg(t) }),
 			)
@@ -215,7 +216,7 @@ func (m Model) View() string {
 	if solver := m.currentSolver(); solver != nil {
 		solverName = solver.Name()
 	}
-	status := RenderStatusBar(m.problem, m.solution, m.mode, solverName, m.filtering, m.filterText, m.sortMode, m.width)
+	status := RenderStatusBar(m.problem, m.solution, m.mode, solverName, m.filtering, m.filterText, m.sortMode, m.solveErr, m.width)
 	status = lipgloss.NewStyle().Width(m.width).Render(status)
 
 	return lipgloss.JoinVertical(lipgloss.Left, main, detail, status)

--- a/internal/tui/bars.go
+++ b/internal/tui/bars.go
@@ -81,7 +81,7 @@ func RenderDetailBar(p *tomo.Problem, s *tomo.Solution, linkIdx int, w int) stri
 }
 
 // RenderStatusBar renders the bottom status line.
-func RenderStatusBar(p *tomo.Problem, s *tomo.Solution, mode viewMode, solver string, filtering bool, filterText string, sortMode int, w int) string {
+func RenderStatusBar(p *tomo.Problem, s *tomo.Solution, mode viewMode, solver string, filtering bool, filterText string, sortMode int, solveErr string, w int) string {
 	hint := "[h]heatmap"
 	if mode == viewHeatmap {
 		hint = "[t]tree"
@@ -98,6 +98,9 @@ func RenderStatusBar(p *tomo.Problem, s *tomo.Solution, mode viewMode, solver st
 	left := fmt.Sprintf(" %s [/]filter [s]sort:%s [m]solver [?]help [q]quit  solver=%s", hint, sortLabel, solver)
 	if filtering {
 		left = fmt.Sprintf(" FILTER: %s█  (Enter=apply  Esc=cancel)", filterText)
+	}
+	if solveErr != "" {
+		left = " " + alertStyle.Render("solve error: "+solveErr)
 	}
 	rank := 0
 	if p.Quality != nil {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -272,7 +272,7 @@ func TestRenderDetailBar_CongestedLink(t *testing.T) {
 
 func TestRenderStatusBar_TreeMode(t *testing.T) {
 	p, s := testFixture(t)
-	out := RenderStatusBar(p, s, viewTree, "tikhonov", false, "", 0, 120)
+	out := RenderStatusBar(p, s, viewTree, "tikhonov", false, "", 0, "", 120)
 	if !strings.Contains(out, "[h]heatmap") {
 		t.Error("expected '[h]heatmap' hint in tree mode")
 	}
@@ -280,7 +280,7 @@ func TestRenderStatusBar_TreeMode(t *testing.T) {
 
 func TestRenderStatusBar_HeatmapMode(t *testing.T) {
 	p, s := testFixture(t)
-	out := RenderStatusBar(p, s, viewHeatmap, "tikhonov", false, "", 0, 120)
+	out := RenderStatusBar(p, s, viewHeatmap, "tikhonov", false, "", 0, "", 120)
 	if !strings.Contains(out, "[t]tree") {
 		t.Error("expected '[t]tree' hint in heatmap mode")
 	}
@@ -288,7 +288,7 @@ func TestRenderStatusBar_HeatmapMode(t *testing.T) {
 
 func TestRenderStatusBar_FilterActive(t *testing.T) {
 	p, s := testFixture(t)
-	out := RenderStatusBar(p, s, viewTree, "tikhonov", true, "test", 0, 120)
+	out := RenderStatusBar(p, s, viewTree, "tikhonov", true, "test", 0, "", 120)
 	if !strings.Contains(out, "FILTER:") {
 		t.Error("expected 'FILTER:' when filtering is active")
 	}
@@ -301,7 +301,7 @@ func TestRenderStatusBar_SortModes(t *testing.T) {
 	p, s := testFixture(t)
 	labels := []string{"default", "delay↓", "delay↑", "name", "coverage"}
 	for i, label := range labels {
-		out := RenderStatusBar(p, s, viewTree, "test", false, "", i, 120)
+		out := RenderStatusBar(p, s, viewTree, "test", false, "", i, "", 120)
 		if !strings.Contains(out, label) {
 			t.Errorf("sort mode %d: expected %q in output", i, label)
 		}

--- a/tomo/nnls.go
+++ b/tomo/nnls.go
@@ -66,9 +66,11 @@ func lawsonHanson(A *mat.Dense, b *mat.VecDense, n, m, maxIter int) (*mat.VecDen
 	// Z = zero set (indices where x = 0, constrained)
 	passive := make([]bool, n) // passive[j] = true means j is in P
 
+	At := A.T()
+
 	// w = Aᵀ(b - Ax), the negative gradient
 	w := mat.NewVecDense(n, nil)
-	computeGradient(A, b, x, w, m, n)
+	computeGradient(At, b, x, w, m)
 
 	iter := 0
 	for iter < maxIter {
@@ -145,21 +147,21 @@ func lawsonHanson(A *mat.Dense, b *mat.VecDense, n, m, maxIter int) (*mat.VecDen
 		}
 
 		// Recompute gradient
-		computeGradient(A, b, x, w, m, n)
+		computeGradient(At, b, x, w, m)
 		iter++
 	}
 
 	return x, iter, nil
 }
 
-// computeGradient computes w = Aᵀ(b - Ax)
-func computeGradient(A *mat.Dense, b, x, w *mat.VecDense, m, n int) {
+// computeGradient computes w = Aᵀ(b - Ax). At must be the transpose of A.
+func computeGradient(At mat.Matrix, b, x, w *mat.VecDense, m int) {
 	// r = b - Ax
 	r := mat.NewVecDense(m, nil)
-	r.MulVec(A, x)
+	r.MulVec(At.T(), x)
 	r.SubVec(b, r)
 	// w = Aᵀr
-	w.MulVec(A.T(), r)
+	w.MulVec(At, r)
 }
 
 // solvePassiveLS solves min ||A_P * z_P - b||₂ using QR factorization.

--- a/tomo/vardi.go
+++ b/tomo/vardi.go
@@ -58,10 +58,15 @@ func (s *VardiEMSolver) Solve(p *Problem) (*Solution, error) {
 		x[j] = 1.0
 	}
 
+	xNew := make([]float64, n)
+	count := make([]float64, n)
+
 	var iter int
 	for iter = 0; iter < maxIter; iter++ {
-		xNew := make([]float64, n)
-		count := make([]float64, n) // number of contributions per link
+		for j := range xNew {
+			xNew[j] = 0
+			count[j] = 0
+		}
 
 		// E-step: for each path i, distribute b_i to links proportionally
 		for i := 0; i < m; i++ {
@@ -103,7 +108,7 @@ func (s *VardiEMSolver) Solve(p *Problem) (*Solution, error) {
 			}
 		}
 
-		x = xNew
+		copy(x, xNew)
 		if maxRel < tol {
 			iter++
 			break

--- a/topology/graph.go
+++ b/topology/graph.go
@@ -79,11 +79,23 @@ func (g *Graph) NumNodes() int { g.mu.RLock(); defer g.mu.RUnlock(); return len(
 // NumLinks returns the number of links.
 func (g *Graph) NumLinks() int { g.mu.RLock(); defer g.mu.RUnlock(); return len(g.links) }
 
-// Links returns all links.
-func (g *Graph) Links() []tomo.Link { g.mu.RLock(); defer g.mu.RUnlock(); return g.links }
+// Links returns a copy of all links.
+func (g *Graph) Links() []tomo.Link {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	out := make([]tomo.Link, len(g.links))
+	copy(out, g.links)
+	return out
+}
 
-// Nodes returns all nodes.
-func (g *Graph) Nodes() []tomo.Node { g.mu.RLock(); defer g.mu.RUnlock(); return g.nodes }
+// Nodes returns a copy of all nodes.
+func (g *Graph) Nodes() []tomo.Node {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	out := make([]tomo.Node, len(g.nodes))
+	copy(out, g.nodes)
+	return out
+}
 
 // Neighbors returns node IDs adjacent to the given node.
 func (g *Graph) Neighbors(nodeID int) []int {


### PR DESCRIPTION
## Summary
- **CSV**: flush before error check so write failures aren't silently lost
- **Graph**: `Links()`/`Nodes()` return copies to prevent callers mutating shared state
- **NNLS**: precompute A transpose once instead of recomputing every gradient call
- **Vardi EM**: reuse slices across iterations instead of allocating per-loop
- **TUI**: surface solver errors in status bar instead of silently discarding

## Test plan
- [x] `go test -short -tags tui ./tomo/ ./topology/ ./internal/format/ ./internal/tui/` all pass