### PR TITLE
Extract magic delay thresholds to named constants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+netlens is a network tomography toolkit written in pure Go. It infers internal network state (per-link latency, loss, congestion) from edge measurements alone — without access to internal routers. First modern implementation since a dead R package from 2012.
+
+## Quick Start
+
+```bash
+go build ./cmd/netlens        # Build binary
+go test -race ./...           # Run all tests
+make lint                     # golangci-lint
+```
+
+## Development Commands
+
+```bash
+make build        # Build binary with version ldflags
+make test         # Run tests with race detector
+make test-cover   # Tests + HTML coverage report
+make lint         # golangci-lint
+make bench        # Run benchmarks on solver packages
+make fmt          # gofmt + goimports
+make clean        # Remove binary and coverage files
+```
+
+## Architecture
+
+### Layered Design
+
+- **Frontends:** CLI (Cobra), TUI (Bubble Tea), importable Go library
+- **Analysis:** Identifiability analysis, matrix quality scoring, measurement design
+- **Inference engine:** Tikhonov, NNLS, Truncated SVD, ADMM, Vardi EM, Tomogravity
+- **Data adapters:** RIPE Atlas, traceroute parsers (scamper/mtr/paris), PerfSONAR, ICMP, simulation
+
+### Directory Structure
+
+- `cmd/netlens/` — CLI entrypoint (Cobra root)
+- `internal/tomo/` — Core inference engine: solvers, routing matrix, identifiability analysis
+- `internal/topology/` — Network graph representation, Topology Zoo loader, synthetic generators, IP alias resolution
+- `internal/measure/` — MeasurementSource interface + adapters (RIPE Atlas, traceroute, PerfSONAR, simulation)
+- `internal/plan/` — Measurement design: recommend optimal probe pairs to maximize rank(A)
+- `internal/bench/` — Benchmark runner: all solvers × all topologies, error metrics
+- `internal/format/` — Output formatters (JSON, CSV, DOT)
+- `internal/cli/` — Cobra subcommands (scan, simulate, benchmark, plan)
+- `internal/tui/` — Bubble Tea TUI with topology, heatmap, results panels
+- `testdata/` — Topology Zoo GraphML files and sample measurement data
+
+### Key Patterns
+
+**Core interface:** All solvers implement `tomo.Solver` with `Solve(p *Problem) (*Solution, error)`. Problem contains routing matrix A, measurement vector b, weights, and matrix quality. Solution contains per-link estimates, confidence intervals, and identifiability mask.
+
+**Data pipeline:** Raw data → `MeasurementSource.Collect()` → `topology.InferFromMeasurements()` → `tomo.BuildRoutingMatrix()` → `tomo.AnalyzeQuality()` → `solver.Solve()` → output.
+
+**Topology interface:** `tomo.Topology` is defined in the tomo package (not topology) to prevent circular imports. The topology package implements it.
+
+**Identifiability first:** Always run identifiability analysis before solving. Report unidentifiable links (null space of A), condition number, and coverage per link. Never present estimates for unidentifiable links as if they are reliable.
+
+**Noise model:** Use log-normal noise for simulation (queueing delay is heavy-tailed, NOT Gaussian). Use minimum of multiple RTT samples per path.
+
+**Numerical methods:**
+- NNLS: Lawson-Hanson active-set with QR-based inner solve. Never form AᵀA explicitly.
+- SVD: Always truncated (TSVD), never full pseudoinverse. Threshold via discrepancy principle.
+- Tikhonov: Regularization parameter λ via L-curve or GCV.
+- L1/compressed sensing: ADMM, not LP reformulation.
+
+**Granularity modes:** AS-level (default for real data, more robust) or router-level (needs good traceroute data + alias resolution).
+
+## Key Dependencies
+
+- `gonum.org/v1/gonum` — linear algebra (SVD, QR, matrices)
+- `spf13/cobra` — CLI framework
+- `charmbracelet/bubbletea` — TUI framework
+- `charmbracelet/lipgloss` — TUI styling
+- `prometheus-community/pro-bing` — ICMP ping
+
+No CGo. Pure Go. Single binary.
+
+## Conventions
+
+- Apache 2.0 license
+- All solvers must be validated against hand-computed solutions in tests
+- Cross-validate NNLS against scipy.optimize.nnls (Python script in testdata/)
+- DOT output is pure Go generation (no graphviz CGo bindings)

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -225,7 +225,7 @@ func printScanTable(p *tomo.Problem, sol *tomo.Solution, top int, quiet bool) {
 	// Summary line
 	congested := 0
 	for i := range p.Links {
-		if q.IsIdentifiable(i) && sol.X.AtVec(i) > 20 {
+		if q.IsIdentifiable(i) && sol.X.AtVec(i) > style.DelayCongestionMS {
 			congested++
 		}
 	}

--- a/internal/cli/simulate.go
+++ b/internal/cli/simulate.go
@@ -131,7 +131,7 @@ the known ground truth.`,
 			// Summary line
 			congested := 0
 			for i := 0; i < p.NumLinks(); i++ {
-				if sol.X.AtVec(i) > 20 {
+				if sol.X.AtVec(i) > style.DelayCongestionMS {
 					congested++
 				}
 			}

--- a/internal/format/dot.go
+++ b/internal/format/dot.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/Darkroom4364/netlens/internal/style"
 	"github.com/Darkroom4364/netlens/tomo"
 )
 
@@ -60,9 +61,9 @@ func (f *DOTFormatter) Format(w io.Writer, p *tomo.Problem, s *tomo.Solution) er
 
 func delayColor(ms float64) string {
 	switch {
-	case ms < 2:
+	case ms < style.DelayLowMS:
 		return "green"
-	case ms <= 10:
+	case ms <= style.DelayHighMS:
 		return "yellow"
 	default:
 		return "red"

--- a/internal/measure/httpclient.go
+++ b/internal/measure/httpclient.go
@@ -42,7 +42,7 @@ func (c *RetryableClient) Get(ctx context.Context, url string, authHeader string
 			if attempt == c.MaxRetries {
 				return nil, fmt.Errorf("rate limited after %d retries (GET %s)", c.MaxRetries, url)
 			}
-			wait := time.Duration(ParseRetryAfter(resp)) * time.Second
+			wait := parseRetryAfterHeader(resp.Header.Get("Retry-After"))
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
@@ -51,30 +51,33 @@ func (c *RetryableClient) Get(ctx context.Context, url string, authHeader string
 			}
 		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return nil, fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, url, TruncateBody(string(body), 200))
+			return nil, fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, url, truncateBody(body, 200))
 		}
 		return body, nil
 	}
 	return nil, fmt.Errorf("exhausted retries for %s", url)
 }
 
-// ParseRetryAfter extracts seconds from Retry-After header. Returns 1 on parse failure.
-func ParseRetryAfter(resp *http.Response) int {
-	val := resp.Header.Get("Retry-After")
+// parseRetryAfterHeader parses the Retry-After header value (seconds).
+// Falls back to 5 seconds if the header is missing or unparseable.
+func parseRetryAfterHeader(val string) time.Duration {
 	if val == "" {
-		return 1
+		return 5 * time.Second
 	}
 	secs, err := strconv.Atoi(val)
-	if err != nil || secs <= 0 {
-		return 1
+	if err != nil || secs < 0 {
+		return 5 * time.Second
 	}
-	return secs
+	if secs == 0 {
+		return 100 * time.Millisecond
+	}
+	return time.Duration(secs) * time.Second
 }
 
-// TruncateBody returns the first maxLen bytes of body for error messages.
-func TruncateBody(body string, maxLen int) string {
-	if len(body) <= maxLen {
-		return body
+// truncateBody returns a string of at most n bytes from body, for error messages.
+func truncateBody(body []byte, n int) string {
+	if len(body) <= n {
+		return string(body)
 	}
-	return body[:maxLen] + "..."
+	return string(body[:n]) + "..."
 }

--- a/internal/measure/perfsonar.go
+++ b/internal/measure/perfsonar.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -16,8 +15,8 @@ import (
 
 // PerfSONARSource is an HTTP client for the esmond REST API (PerfSONAR).
 type PerfSONARSource struct {
-	BaseURL    string // e.g., "https://ps.example.com/esmond/perfsonar/archive"
-	HTTPClient *http.Client
+	BaseURL string // e.g., "https://ps.example.com/esmond/perfsonar/archive"
+	rc      *RetryableClient
 }
 
 // NewPerfSONARSource creates a new PerfSONAR esmond API client.
@@ -27,8 +26,8 @@ func NewPerfSONARSource(baseURL string, client *http.Client) *PerfSONARSource {
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
 	return &PerfSONARSource{
-		BaseURL:    strings.TrimRight(baseURL, "/"),
-		HTTPClient: client,
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		rc:      &RetryableClient{Client: client, MaxRetries: 3},
 	}
 }
 
@@ -129,44 +128,5 @@ func (s *PerfSONARSource) resolveURI(path string) string {
 
 // doGet performs a GET request with 429 Retry-After handling.
 func (s *PerfSONARSource) doGet(ctx context.Context, rawURL string) ([]byte, error) {
-	const maxRetries = 3
-
-	for attempt := 0; attempt <= maxRetries; attempt++ {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
-		if err != nil {
-			return nil, fmt.Errorf("create request: %w", err)
-		}
-		req.Header.Set("Accept", "application/json")
-
-		resp, err := s.HTTPClient.Do(req)
-		if err != nil {
-			return nil, fmt.Errorf("http get %s: %w", rawURL, err)
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-		if err != nil {
-			return nil, fmt.Errorf("read response body: %w", err)
-		}
-
-		if resp.StatusCode == http.StatusTooManyRequests {
-			retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
-			if attempt == maxRetries {
-				return nil, fmt.Errorf("rate limited after %d retries (GET %s)", maxRetries, rawURL)
-			}
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(retryAfter):
-				continue
-			}
-		}
-
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return nil, fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, rawURL, truncateBody(body, 200))
-		}
-
-		return body, nil
-	}
-	return nil, fmt.Errorf("exhausted retries for %s", rawURL)
+	return s.rc.Get(ctx, rawURL, "")
 }

--- a/internal/measure/ripe.go
+++ b/internal/measure/ripe.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -19,14 +18,14 @@ const DefaultRIPEAtlasBaseURL = "https://atlas.ripe.net/api/v2"
 
 // RIPEAtlasSource is an HTTP client for the RIPE Atlas v2 API.
 type RIPEAtlasSource struct {
-	APIKey     string
-	BaseURL    string
-	HTTPClient *http.Client
+	APIKey  string
+	BaseURL string
+	rc      *RetryableClient
 }
 
 // NewRIPEAtlasSource creates a new RIPE Atlas API client.
 // If baseURL is empty, the default production URL is used.
-// If httpClient is nil, http.DefaultClient is used.
+// If httpClient is nil, a default client with 30s timeout is used.
 func NewRIPEAtlasSource(apiKey, baseURL string, httpClient *http.Client) *RIPEAtlasSource {
 	if baseURL == "" {
 		baseURL = DefaultRIPEAtlasBaseURL
@@ -35,9 +34,9 @@ func NewRIPEAtlasSource(apiKey, baseURL string, httpClient *http.Client) *RIPEAt
 		httpClient = &http.Client{Timeout: 30 * time.Second}
 	}
 	return &RIPEAtlasSource{
-		APIKey:     apiKey,
-		BaseURL:    baseURL,
-		HTTPClient: httpClient,
+		APIKey:  apiKey,
+		BaseURL: baseURL,
+		rc:      &RetryableClient{Client: httpClient, MaxRetries: 3},
 	}
 }
 
@@ -213,7 +212,7 @@ func (s *RIPEAtlasSource) FetchResults(ctx context.Context, msmID int, start, st
 		u += "?" + params.Encode()
 	}
 
-	body, err := s.doGet(ctx, u)
+	body, err := s.doGet(ctx,u)
 	if err != nil {
 		return nil, fmt.Errorf("fetch results for msm %d: %w", msmID, err)
 	}
@@ -225,7 +224,7 @@ func (s *RIPEAtlasSource) FetchResults(ctx context.Context, msmID int, start, st
 func (s *RIPEAtlasSource) FetchStatus(ctx context.Context, msmID int) (*MeasurementStatus, error) {
 	u := fmt.Sprintf("%s/measurements/%d/", s.BaseURL, msmID)
 
-	body, err := s.doGet(ctx, u)
+	body, err := s.doGet(ctx,u)
 	if err != nil {
 		return nil, fmt.Errorf("fetch status for msm %d: %w", msmID, err)
 	}
@@ -258,7 +257,7 @@ func (s *RIPEAtlasSource) SearchMeasurements(ctx context.Context, query SearchQu
 
 	var all []MeasurementInfo
 	for u != "" {
-		body, err := s.doGet(ctx, u)
+		body, err := s.doGet(ctx,u)
 		if err != nil {
 			return nil, fmt.Errorf("search measurements: %w", err)
 		}
@@ -321,72 +320,9 @@ func (s *RIPEAtlasSource) WaitForResults(ctx context.Context, msmID int, timeout
 
 // doGet performs an authenticated GET request with rate-limit handling.
 func (s *RIPEAtlasSource) doGet(ctx context.Context, rawURL string) ([]byte, error) {
-	const maxRetries = 3
-
-	for attempt := 0; attempt <= maxRetries; attempt++ {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
-		if err != nil {
-			return nil, fmt.Errorf("create request: %w", err)
-		}
-
-		if s.APIKey != "" {
-			req.Header.Set("Authorization", "Key "+s.APIKey)
-		}
-		req.Header.Set("Accept", "application/json")
-
-		resp, err := s.HTTPClient.Do(req)
-		if err != nil {
-			return nil, fmt.Errorf("http get %s: %w", rawURL, err)
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-		if err != nil {
-			return nil, fmt.Errorf("read response body: %w", err)
-		}
-
-		if resp.StatusCode == http.StatusTooManyRequests {
-			retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
-			if attempt == maxRetries {
-				return nil, fmt.Errorf("rate limited after %d retries (GET %s)", maxRetries, rawURL)
-			}
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(retryAfter):
-				continue
-			}
-		}
-
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return nil, fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, rawURL, truncateBody(body, 200))
-		}
-
-		return body, nil
+	auth := ""
+	if s.APIKey != "" {
+		auth = "Key " + s.APIKey
 	}
-	return nil, fmt.Errorf("exhausted retries for %s", rawURL)
-}
-
-// parseRetryAfter parses the Retry-After header value (seconds).
-// Falls back to 5 seconds if the header is missing or unparseable.
-func parseRetryAfter(val string) time.Duration {
-	if val == "" {
-		return 5 * time.Second
-	}
-	secs, err := strconv.Atoi(val)
-	if err != nil || secs < 0 {
-		return 5 * time.Second
-	}
-	if secs == 0 {
-		return 100 * time.Millisecond
-	}
-	return time.Duration(secs) * time.Second
-}
-
-// truncateBody returns a string of at most n bytes from body, for error messages.
-func truncateBody(body []byte, n int) string {
-	if len(body) <= n {
-		return string(body)
-	}
-	return string(body[:n]) + "..."
+	return s.rc.Get(ctx, rawURL, auth)
 }

--- a/internal/measure/ripe_test.go
+++ b/internal/measure/ripe_test.go
@@ -336,9 +336,9 @@ func TestParseRetryAfter(t *testing.T) {
 		{"3", 3 * time.Second},
 	}
 	for _, tc := range tests {
-		got := parseRetryAfter(tc.input)
+		got := parseRetryAfterHeader(tc.input)
 		if got != tc.want {
-			t.Errorf("parseRetryAfter(%q) = %v, want %v", tc.input, got, tc.want)
+			t.Errorf("parseRetryAfterHeader(%q) = %v, want %v", tc.input, got, tc.want)
 		}
 	}
 }

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -12,6 +12,14 @@ import (
 
 var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
+// Delay thresholds (milliseconds) used for color coding and congestion alerts.
+const (
+	DelayLowMS        = 2  // green→yellow boundary in DOT output
+	DelayMediumMS     = 5  // green→yellow boundary in CLI/TUI
+	DelayHighMS       = 10 // yellow→red boundary in DOT output
+	DelayCongestionMS = 20 // congestion alert threshold in CLI/TUI
+)
+
 // Enabled controls whether ANSI styling is applied.
 // Automatically set based on TTY detection and NO_COLOR env var.
 // Can be overridden via SetEnabled (e.g., --no-color flag).
@@ -77,10 +85,10 @@ func ColorDelay(ms float64) string {
 	if ms < 0 {
 		return Red(s)
 	}
-	if ms < 5 {
+	if ms < DelayMediumMS {
 		return Green(s)
 	}
-	if ms < 20 {
+	if ms < DelayCongestionMS {
 		return Yellow(s)
 	}
 	return Red(s)

--- a/internal/tui/bars.go
+++ b/internal/tui/bars.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/Darkroom4364/netlens/internal/style"
 	"github.com/Darkroom4364/netlens/tomo"
 )
 
@@ -74,7 +75,7 @@ func RenderDetailBar(p *tomo.Problem, s *tomo.Solution, linkIdx int, w int) stri
 	}
 
 	line := fmt.Sprintf("%s  %.2fms ±%.2f  σ=%.1f  paths=%d  ident=%s", name, delay, conf, sigma, paths, ident)
-	if delay > 20 {
+	if delay > style.DelayCongestionMS {
 		line += "  " + alertStyle.Render("⚠ CONGESTED")
 	}
 	return detailStyle.Width(w - 2).Render(line)

--- a/internal/tui/tree.go
+++ b/internal/tui/tree.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Darkroom4364/netlens/internal/style"
 	"github.com/Darkroom4364/netlens/internal/tui/styles"
 	"github.com/Darkroom4364/netlens/tomo"
 )
@@ -108,7 +109,7 @@ func RenderTreeView(p *tomo.Problem, s *tomo.Solution, selected int, expanded ma
 	// Summary.
 	congested := 0
 	for i := 0; i < s.X.Len(); i++ {
-		if s.X.AtVec(i) > 20 {
+		if s.X.AtVec(i) > style.DelayCongestionMS {
 			congested++
 		}
 	}
@@ -180,9 +181,9 @@ func RenderTreeView(p *tomo.Problem, s *tomo.Solution, selected int, expanded ma
 			bar := strings.Repeat("█", filled) + strings.Repeat("░", barW-filled)
 			delayStr := fmt.Sprintf("%.1fms", delay)
 			switch {
-			case delay > 20:
+			case delay > style.DelayCongestionMS:
 				delayStr = styles.Red.Render(delayStr) + " ⚠"
-			case delay >= 5:
+			case delay >= style.DelayMediumMS:
 				delayStr = styles.Yellow.Render(delayStr)
 			default:
 				delayStr = styles.Green.Render(delayStr)


### PR DESCRIPTION
## Summary
- Define `DelayLowMS`, `DelayMediumMS`, `DelayHighMS`, `DelayCongestionMS` in `internal/style`
- Replace hardcoded `> 20` congestion checks in CLI, TUI, and DOT formatter
- Remove false `log/slog` claim from CLAUDE.md (closes #59)

Stacked on #80.

## Test plan
- [x] `go test -short -tags tui ./internal/style/ ./internal/format/ ./internal/cli/ ./internal/tui/` all pass