### PR TITLE
Fix review comments: bootstrap race, CI matrix, test-gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.23', '1.24']
+        go-version: ['1.25', '1.26']
 
     steps:
       - uses: actions/checkout@v4
@@ -89,7 +89,7 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.test.result }}" == "failure" || "${{ needs.lint.result }}" == "failure" ]]; then
+          if [[ "${{ needs.changes.result }}" == "failure" || "${{ needs.test.result }}" == "failure" || "${{ needs.lint.result }}" == "failure" ]]; then
             echo "One or more required jobs failed"
             exit 1
           fi

--- a/tomo/bootstrap.go
+++ b/tomo/bootstrap.go
@@ -90,6 +90,7 @@ func Bootstrap(p *Problem, solver Solver, cfg BootstrapConfig) (*Solution, error
 	g.SetLimit(numWorkers)
 
 	for b := 0; b < cfg.NumSamples; b++ {
+		b := b // capture per-iteration value for goroutine closure
 		g.Go(func() error {
 			wid := <-slots
 			defer func() { slots <- wid }()
@@ -110,6 +111,8 @@ func Bootstrap(p *Problem, solver Solver, cfg BootstrapConfig) (*Solution, error
 				buf.bData[i] = p.B.AtVec(idx)
 			}
 
+			// buf.aData/bData are aliased into the matrices below; safe because
+			// the goroutine holds the slot exclusively until Solve returns.
 			bp := &Problem{
 				A: mat.NewDense(m, n, buf.aData),
 				B: mat.NewVecDense(m, buf.bData),

--- a/tomo/problem.go
+++ b/tomo/problem.go
@@ -9,6 +9,7 @@ import (
 
 // Problem represents a network tomography inverse problem: y = Ax + e
 // where A is the routing matrix, x is per-link metrics, y is end-to-end measurements.
+// A Problem must not be copied after construction (contains sync.Once).
 type Problem struct {
 	Topo    Topology
 	A       *mat.Dense    // Routing matrix (m paths × n links)


### PR DESCRIPTION
## Summary
- Shadow loop var `b` in bootstrap to prevent goroutine closure data race
- Document buffer aliasing invariant and Problem no-copy constraint
- Bump CI test matrix from 1.23/1.24 to 1.25/1.26 to match `go.mod` minimum
- Include `changes` job failure in test-gate check

🤖 Generated with [Claude Code](https://claude.com/claude-code)