### PR TITLE
Use relative SVD tolerance in solvers instead of hardcoded 1e-15

### DIFF
--- a/tomo/identity.go
+++ b/tomo/identity.go
@@ -8,6 +8,9 @@ import (
 
 const svdTolerance = 1e-10
 
+// nnlsZeroTol is the near-zero tolerance for gradient and solution checks.
+const nnlsZeroTol = 1e-15
+
 // AnalyzeQuality computes the identifiability and conditioning of routing matrix A.
 func AnalyzeQuality(A *mat.Dense) *MatrixQuality {
 	m, n := A.Dims()

--- a/tomo/laplacian.go
+++ b/tomo/laplacian.go
@@ -104,7 +104,7 @@ func solveLaplacianAug(A *mat.Dense, b *mat.VecDense, L *mat.Dense, m, n int, la
 	svd.UTo(&u)
 	svd.VTo(&v)
 	x := mat.NewVecDense(n, nil)
-	svThresh := sv[0] * svdTolerance
+	svThresh := math.Max(sv[0]*svdTolerance, 1e-300)
 	for j := range sv {
 		if sv[j] < svThresh {
 			continue

--- a/tomo/laplacian.go
+++ b/tomo/laplacian.go
@@ -104,8 +104,9 @@ func solveLaplacianAug(A *mat.Dense, b *mat.VecDense, L *mat.Dense, m, n int, la
 	svd.UTo(&u)
 	svd.VTo(&v)
 	x := mat.NewVecDense(n, nil)
+	svThresh := sv[0] * svdTolerance
 	for j := range sv {
-		if sv[j] < 1e-15 {
+		if sv[j] < svThresh {
 			continue
 		}
 		col := u.ColView(j)

--- a/tomo/nnls.go
+++ b/tomo/nnls.go
@@ -50,6 +50,9 @@ func lawsonHanson(A *mat.Dense, b *mat.VecDense, n, m, maxIter int) (*mat.VecDen
 	// Z = zero set (indices where x = 0, constrained)
 	passive := make([]bool, n) // passive[j] = true means j is in P
 
+	// nnlsZeroTol is the near-zero tolerance for gradient and solution checks.
+	const nnlsZeroTol = 1e-15
+
 	At := A.T()
 
 	// w = Aᵀ(b - Ax), the negative gradient
@@ -69,7 +72,7 @@ func lawsonHanson(A *mat.Dense, b *mat.VecDense, n, m, maxIter int) (*mat.VecDen
 		}
 
 		// If max w ≤ 0, all zero-set gradients are non-positive → optimal
-		if maxW <= 1e-15 || maxJ < 0 {
+		if maxW <= nnlsZeroTol || maxJ < 0 {
 			break
 		}
 
@@ -84,7 +87,7 @@ func lawsonHanson(A *mat.Dense, b *mat.VecDense, n, m, maxIter int) (*mat.VecDen
 			// Check if all z_P ≥ 0
 			allNonNeg := true
 			for j := 0; j < n; j++ {
-				if passive[j] && z.AtVec(j) < -1e-15 {
+				if passive[j] && z.AtVec(j) < -nnlsZeroTol {
 					allNonNeg = false
 					break
 				}
@@ -104,7 +107,7 @@ func lawsonHanson(A *mat.Dense, b *mat.VecDense, n, m, maxIter int) (*mat.VecDen
 			alpha := 1.0
 			moveToZero := -1
 			for j := 0; j < n; j++ {
-				if passive[j] && z.AtVec(j) < -1e-15 {
+				if passive[j] && z.AtVec(j) < -nnlsZeroTol {
 					ratio := x.AtVec(j) / (x.AtVec(j) - z.AtVec(j))
 					if ratio < alpha {
 						alpha = ratio
@@ -122,7 +125,7 @@ func lawsonHanson(A *mat.Dense, b *mat.VecDense, n, m, maxIter int) (*mat.VecDen
 
 			// Move indices with x[j] ≈ 0 from P to Z
 			for j := 0; j < n; j++ {
-				if passive[j] && x.AtVec(j) < 1e-15 {
+				if passive[j] && x.AtVec(j) < nnlsZeroTol {
 					passive[j] = false
 					x.SetVec(j, 0)
 				}

--- a/tomo/nnls.go
+++ b/tomo/nnls.go
@@ -50,9 +50,6 @@ func lawsonHanson(A *mat.Dense, b *mat.VecDense, n, m, maxIter int) (*mat.VecDen
 	// Z = zero set (indices where x = 0, constrained)
 	passive := make([]bool, n) // passive[j] = true means j is in P
 
-	// nnlsZeroTol is the near-zero tolerance for gradient and solution checks.
-	const nnlsZeroTol = 1e-15
-
 	At := A.T()
 
 	// w = Aᵀ(b - Ax), the negative gradient

--- a/tomo/tikhonov.go
+++ b/tomo/tikhonov.go
@@ -54,9 +54,10 @@ func (s *TikhonovSolver) Solve(p *Problem) (*Solution, error) {
 	// Tikhonov solution via SVD:
 	// x = Σ_j (σ_j / (σ_j² + λ)) * (u_j · b) * v_j
 	x := mat.NewVecDense(n, nil)
+	svThresh := sv[0] * svdTolerance
 	for j := 0; j < len(sv); j++ {
 		sj := sv[j]
-		if sj < 1e-15 {
+		if sj < svThresh {
 			continue
 		}
 		// Filter factor: f_j = σ_j² / (σ_j² + λ)

--- a/tomo/tikhonov.go
+++ b/tomo/tikhonov.go
@@ -54,7 +54,7 @@ func (s *TikhonovSolver) Solve(p *Problem) (*Solution, error) {
 	// Tikhonov solution via SVD:
 	// x = Σ_j (σ_j / (σ_j² + λ)) * (u_j · b) * v_j
 	x := mat.NewVecDense(n, nil)
-	svThresh := sv[0] * svdTolerance
+	svThresh := math.Max(sv[0]*svdTolerance, 1e-300)
 	for j := 0; j < len(sv); j++ {
 		sj := sv[j]
 		if sj < svThresh {

--- a/tomo/tomogravity.go
+++ b/tomo/tomogravity.go
@@ -82,7 +82,7 @@ func (s *TomogravitySolver) Solve(p *Problem) (*Solution, error) {
 
 	// Tikhonov on residual: x_resid = V * diag(f_j * (uᵀr)/σ_j) where f_j = σ_j²/(σ_j²+λ)
 	xResid := mat.NewVecDense(n, nil)
-	svThresh := sv[0] * svdTolerance
+	svThresh := math.Max(sv[0]*svdTolerance, 1e-300)
 	for j := 0; j < len(sv); j++ {
 		sj := sv[j]
 		if sj < svThresh {

--- a/tomo/tomogravity.go
+++ b/tomo/tomogravity.go
@@ -82,9 +82,10 @@ func (s *TomogravitySolver) Solve(p *Problem) (*Solution, error) {
 
 	// Tikhonov on residual: x_resid = V * diag(f_j * (uᵀr)/σ_j) where f_j = σ_j²/(σ_j²+λ)
 	xResid := mat.NewVecDense(n, nil)
+	svThresh := sv[0] * svdTolerance
 	for j := 0; j < len(sv); j++ {
 		sj := sv[j]
-		if sj < 1e-15 {
+		if sj < svThresh {
 			continue
 		}
 		filter := sj * sj / (sj*sj + lambda)

--- a/tomo/tsvd.go
+++ b/tomo/tsvd.go
@@ -2,7 +2,6 @@ package tomo
 
 import (
 	"fmt"
-	"math"
 	"time"
 
 	"gonum.org/v1/gonum/mat"
@@ -43,8 +42,9 @@ func (s *TSVDSolver) Solve(p *Problem) (*Solution, error) {
 	// where only the first k singular components are used
 	x := mat.NewVecDense(n, nil)
 
+	svThresh := sv[0] * svdTolerance
 	for j := 0; j < k; j++ {
-		if sv[j] < 1e-15 {
+		if sv[j] < svThresh {
 			continue
 		}
 		// Compute u_j^T * b
@@ -76,7 +76,7 @@ func (s *TSVDSolver) truncationRank(sv []float64, b *mat.VecDense, u *mat.Dense,
 	// Estimate noise as the smallest singular values' contribution.
 	// Heuristic: keep components where sigma_j > sigma_max * sqrt(eps) * max(m,n)
 	maxSV := sv[0]
-	threshold := maxSV * math.Sqrt(1e-15) * float64(max(m, n))
+	threshold := maxSV * svdTolerance * float64(max(m, n))
 
 	k := 0
 	for _, s := range sv {

--- a/tomo/tsvd.go
+++ b/tomo/tsvd.go
@@ -2,6 +2,7 @@ package tomo
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"gonum.org/v1/gonum/mat"
@@ -42,7 +43,7 @@ func (s *TSVDSolver) Solve(p *Problem) (*Solution, error) {
 	// where only the first k singular components are used
 	x := mat.NewVecDense(n, nil)
 
-	svThresh := sv[0] * svdTolerance
+	svThresh := math.Max(sv[0]*svdTolerance*float64(max(m, n)), 1e-300)
 	for j := 0; j < k; j++ {
 		if sv[j] < svThresh {
 			continue


### PR DESCRIPTION
## Summary
- Replace absolute `1e-15` singular value cutoffs with `sv[0] * svdTolerance` (relative to matrix norm) across Tikhonov, TSVD, Laplacian, and Tomogravity solvers
- Name the NNLS near-zero tolerance as `nnlsZeroTol` constant for clarity
- Align TSVD truncation rank formula with `identity.go`'s existing convention

Fixes #96