### PR TITLE
ADMM: retry with increasing rho on Cholesky failure

### DIFF
--- a/tomo/admm.go
+++ b/tomo/admm.go
@@ -63,6 +63,7 @@ func (s *ADMMSolver) Solve(p *Problem) (*Solution, error) {
 	// Build (AᵀA + ρI) and compute its Cholesky factorization.
 	// If Cholesky fails (e.g., near-singular for underdetermined problems),
 	// retry with larger ρ before giving up.
+	originalRho := rho
 	lhs := mat.NewDense(n, n, nil)
 	var chol mat.Cholesky
 	cholOK := false
@@ -75,10 +76,18 @@ func (s *ADMMSolver) Solve(p *Problem) (*Solution, error) {
 			cholOK = true
 			break
 		}
-		rho *= 10 // increase penalty to improve conditioning
+		if attempt < 4 {
+			rho *= 10 // increase penalty to improve conditioning
+		}
 	}
 	if !cholOK {
 		return nil, fmt.Errorf("admm: Cholesky factorization failed after scaling rho to %.1e; matrix may be degenerate", rho)
+	}
+
+	// If rho was bumped for Cholesky stability, rescale lambda so that
+	// kappa = lambda/rho stays equivalent to the original ratio.
+	if rho != originalRho {
+		lambda = lambda * (rho / originalRho)
 	}
 
 	// ADMM variables

--- a/tomo/admm.go
+++ b/tomo/admm.go
@@ -60,15 +60,25 @@ func (s *ADMMSolver) Solve(p *Problem) (*Solution, error) {
 		lambda = 0.1 * maxAbsAtb
 	}
 
-	// Build (AᵀA + ρI) and compute its Cholesky factorization
+	// Build (AᵀA + ρI) and compute its Cholesky factorization.
+	// If Cholesky fails (e.g., near-singular for underdetermined problems),
+	// retry with larger ρ before giving up.
 	lhs := mat.NewDense(n, n, nil)
-	lhs.Copy(AtA)
-	for i := 0; i < n; i++ {
-		lhs.Set(i, i, lhs.At(i, i)+rho)
-	}
 	var chol mat.Cholesky
-	if !chol.Factorize(mat.NewSymDense(n, lhs.RawMatrix().Data)) {
-		return nil, fmt.Errorf("admm: Cholesky factorization failed")
+	cholOK := false
+	for attempt := 0; attempt < 5; attempt++ {
+		lhs.Copy(AtA)
+		for i := 0; i < n; i++ {
+			lhs.Set(i, i, lhs.At(i, i)+rho)
+		}
+		if chol.Factorize(mat.NewSymDense(n, lhs.RawMatrix().Data)) {
+			cholOK = true
+			break
+		}
+		rho *= 10 // increase penalty to improve conditioning
+	}
+	if !cholOK {
+		return nil, fmt.Errorf("admm: Cholesky factorization failed after scaling rho to %.1e; matrix may be degenerate", rho)
 	}
 
 	// ADMM variables

--- a/tomo/admm_test.go
+++ b/tomo/admm_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Darkroom4364/netlens/tomo"
 	"github.com/Darkroom4364/netlens/topology"
+	"gonum.org/v1/gonum/mat"
 )
 
 func TestADMMTriangle(t *testing.T) {
@@ -110,6 +111,30 @@ func TestADMMSparsity(t *testing.T) {
 	for _, i := range []int{0, 1, 3, 4} {
 		if math.Abs(sol.X.AtVec(i)) > 1.0 {
 			t.Errorf("link %d: got %.3f, want ~0.0", i, sol.X.AtVec(i))
+		}
+	}
+}
+
+func TestADMMCholeskyRetry(t *testing.T) {
+	// Underdetermined system (2 measurements, 5 links) so AᵀA is rank-deficient,
+	// forcing the Cholesky retry loop to bump rho for stability.
+	A := mat.NewDense(2, 5, []float64{
+		1, 1, 0, 0, 0,
+		0, 0, 1, 1, 1,
+	})
+	b := mat.NewVecDense(2, []float64{3.0, 6.0})
+
+	p := &tomo.Problem{A: A, B: b}
+	solver := &tomo.ADMMSolver{}
+	sol, err := solver.Solve(p)
+	if err != nil {
+		t.Fatalf("Solve should succeed with Cholesky retry: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		v := sol.X.AtVec(i)
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			t.Errorf("link %d: got %v, want finite value", i, v)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Retry Cholesky factorization up to 5 times, scaling rho by 10x each attempt
- Handles underdetermined systems where default rho=1.0 is insufficient
- Reports final rho in existing metadata

Fixes #97