### PR TITLE
NNLS: remove redundant double-transpose in gradient computation

### DIFF
--- a/tomo/nnls.go
+++ b/tomo/nnls.go
@@ -50,11 +50,9 @@ func lawsonHanson(A *mat.Dense, b *mat.VecDense, n, m, maxIter int) (*mat.VecDen
 	// Z = zero set (indices where x = 0, constrained)
 	passive := make([]bool, n) // passive[j] = true means j is in P
 
-	At := A.T()
-
 	// w = Aᵀ(b - Ax), the negative gradient
 	w := mat.NewVecDense(n, nil)
-	computeGradient(At, b, x, w, m)
+	computeGradient(A, b, x, w, m)
 
 	iter := 0
 	for iter < maxIter {
@@ -131,21 +129,21 @@ func lawsonHanson(A *mat.Dense, b *mat.VecDense, n, m, maxIter int) (*mat.VecDen
 		}
 
 		// Recompute gradient
-		computeGradient(At, b, x, w, m)
+		computeGradient(A, b, x, w, m)
 		iter++
 	}
 
 	return x, iter, nil
 }
 
-// computeGradient computes w = Aᵀ(b - Ax). At must be the transpose of A.
-func computeGradient(At mat.Matrix, b, x, w *mat.VecDense, m int) {
+// computeGradient computes w = Aᵀ(b - Ax).
+func computeGradient(A *mat.Dense, b, x, w *mat.VecDense, m int) {
 	// r = b - Ax
 	r := mat.NewVecDense(m, nil)
-	r.MulVec(At.T(), x)
+	r.MulVec(A, x)
 	r.SubVec(b, r)
 	// w = Aᵀr
-	w.MulVec(At, r)
+	w.MulVec(A.T(), r)
 }
 
 // solvePassiveLS solves min ||A_P * z_P - b||₂ using QR factorization.


### PR DESCRIPTION
## Summary
- `computeGradient` now takes `A` directly instead of `At` then calling `At.T()`
- Removed unused `At` variable from `lawsonHanson`

Fixes #95