### PR TITLE
Extract shared negative-delay warning helper in CLI

### DIFF
--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -162,18 +162,7 @@ analysis, solves the inverse problem, and outputs per-link estimates.`,
 				return fmt.Errorf("solve: %w", err)
 			}
 
-			// Warn about negative delay estimates
-			if method != "nnls" {
-				negCount := 0
-				for i := 0; i < sol.X.Len(); i++ {
-					if sol.X.AtVec(i) < 0 {
-						negCount++
-					}
-				}
-				if negCount > 0 {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %d links have negative delay estimates (physically impossible). Consider using --method nnls to enforce non-negativity.\n", negCount)
-				}
-			}
+			warnNegativeDelays(cmd, sol, method)
 
 			if !quiet {
 				fmt.Printf("Solver:         %s\n", sol.Method)

--- a/internal/cli/simulate.go
+++ b/internal/cli/simulate.go
@@ -79,18 +79,7 @@ the known ground truth.`,
 				return fmt.Errorf("solve: %w", err)
 			}
 
-			// Warn about negative delay estimates (skip for NNLS which guarantees non-negativity)
-			if method != "nnls" {
-				negCount := 0
-				for i := 0; i < sol.X.Len(); i++ {
-					if sol.X.AtVec(i) < 0 {
-						negCount++
-					}
-				}
-				if negCount > 0 {
-					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %d links have negative delay estimates (physically impossible). Consider using --method nnls to enforce non-negativity.\n", negCount)
-				}
-			}
+			warnNegativeDelays(cmd, sol, method)
 
 			// Print results
 			topoName := filepath.Base(topoFile)
@@ -186,6 +175,22 @@ the known ground truth.`,
 	_ = cmd.MarkFlagRequired("topology")
 
 	return cmd
+}
+
+// warnNegativeDelays prints a warning to stderr if the solution contains negative estimates.
+func warnNegativeDelays(cmd *cobra.Command, sol *tomo.Solution, method string) {
+	if method == "nnls" {
+		return
+	}
+	negCount := 0
+	for i := 0; i < sol.X.Len(); i++ {
+		if sol.X.AtVec(i) < 0 {
+			negCount++
+		}
+	}
+	if negCount > 0 {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %d links have negative delay estimates (physically impossible). Consider using --method nnls to enforce non-negativity.\n", negCount)
+	}
 }
 
 func getSolver(name string) (tomo.Solver, error) {


### PR DESCRIPTION
## Summary
- Extract identical warning blocks from scan.go and simulate.go into `warnNegativeDelays`
- Net -6 lines

Fixes #106