### PR TITLE
Fix detection rate k calculation (#56)

### DIFF
--- a/internal/bench/bench.go
+++ b/internal/bench/bench.go
@@ -136,7 +136,7 @@ func computeDetectionRate(gt []float64, est *mat.VecDense, quality *tomo.MatrixQ
 	sort.Slice(estLinks, func(i, j int) bool { return estLinks[i].val > estLinks[j].val })
 
 	// Check top-k where k = min(3, len/4, len)
-	k := min(3, len(gtLinks))
+	k := min(3, len(gtLinks)/4, len(gtLinks))
 	if k == 0 {
 		k = 1
 	}


### PR DESCRIPTION
## Summary
- Adds missing `len/4` term to detection rate `k` calculation so it matches the comment: `k = min(3, len/4, len)`

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/bench/...`

Closes #56