### PR TITLE
Improve test coverage for cli, measure, and tui

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -5,8 +5,13 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Darkroom4364/netlens/tomo"
+	"github.com/spf13/cobra"
+	"gonum.org/v1/gonum/mat"
 )
 
 // executeCommand runs the CLI with the given args and captures both the
@@ -346,5 +351,346 @@ func TestCLI_TUISubcommandDetection(t *testing.T) {
 	_, err := executeCommand("tui")
 	if err == nil {
 		t.Error("expected error when tui is called without -t flag")
+	}
+}
+
+// --- Additional coverage tests ---
+
+func TestCLI_SetVersion(t *testing.T) {
+	SetVersion("1.2.3")
+	defer SetVersion("dev")
+
+	out, err := executeCommand("version")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "1.2.3") {
+		t.Fatalf("expected output to contain '1.2.3', got: %s", out)
+	}
+}
+
+func TestCLI_LoadDotEnv(t *testing.T) {
+	dir := t.TempDir()
+	envContent := `# comment line
+TEST_NETLENS_FOO=bar
+TEST_NETLENS_QUOTED="hello world"
+`
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(envContent), 0644); err != nil {
+		t.Fatalf("failed to write .env: %v", err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(origDir)
+		os.Unsetenv("TEST_NETLENS_FOO")
+		os.Unsetenv("TEST_NETLENS_QUOTED")
+	}()
+
+	_, _ = executeCommand("version")
+
+	if got := os.Getenv("TEST_NETLENS_FOO"); got != "bar" {
+		t.Errorf("expected TEST_NETLENS_FOO=bar, got %q", got)
+	}
+	if got := os.Getenv("TEST_NETLENS_QUOTED"); got != "hello world" {
+		t.Errorf("expected TEST_NETLENS_QUOTED='hello world', got %q", got)
+	}
+}
+
+func TestCLI_ScanTableFormat(t *testing.T) {
+	out, err := executeCommand("scan", "--source", "traceroute", "--file", "../../testdata/measurements/ripe_atlas_sample.json", "--format", "table")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected non-empty output for table format")
+	}
+}
+
+func TestCLI_GetSolverAllValid(t *testing.T) {
+	names := []string{"tsvd", "tikhonov", "nnls", "admm", "irl1", "vardi", "tomogravity", "laplacian"}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			s, err := getSolver(name)
+			if err != nil {
+				t.Fatalf("getSolver(%q) returned error: %v", name, err)
+			}
+			if s == nil {
+				t.Fatalf("getSolver(%q) returned nil solver", name)
+			}
+		})
+	}
+}
+
+func TestCLI_GetSolverEmpty(t *testing.T) {
+	_, err := getSolver("")
+	if err == nil {
+		t.Fatal("expected error for empty solver name")
+	}
+	if !strings.Contains(err.Error(), "unknown solver method") {
+		t.Fatalf("expected 'unknown solver method' in error, got: %v", err)
+	}
+}
+
+func TestCLI_WarnNegativeDelays(t *testing.T) {
+	sol := &tomo.Solution{
+		X: mat.NewVecDense(3, []float64{1.0, -0.5, -0.2}),
+	}
+
+	// With tikhonov, should warn about negative delays.
+	cmd := &cobra.Command{}
+	errBuf := new(bytes.Buffer)
+	cmd.SetErr(errBuf)
+	warnNegativeDelays(cmd, sol, "tikhonov")
+	if !strings.Contains(errBuf.String(), "negative delay") {
+		t.Errorf("expected warning about negative delay for tikhonov, got: %q", errBuf.String())
+	}
+
+	// With nnls, should NOT warn (nnls guarantees non-negativity).
+	cmd2 := &cobra.Command{}
+	errBuf2 := new(bytes.Buffer)
+	cmd2.SetErr(errBuf2)
+	warnNegativeDelays(cmd2, sol, "nnls")
+	if errBuf2.Len() > 0 {
+		t.Errorf("expected no warning for nnls, got: %q", errBuf2.String())
+	}
+}
+
+func TestCLI_PrintScanTable(t *testing.T) {
+	// Build a minimal Problem + Solution to exercise printScanTable.
+	p := &tomo.Problem{
+		Links: []tomo.Link{
+			{ID: 0, Src: 1, Dst: 2},
+			{ID: 1, Src: 2, Dst: 3},
+			{ID: 2, Src: 3, Dst: 4},
+		},
+		Quality: &tomo.MatrixQuality{
+			Rank:                3,
+			NumLinks:            3,
+			NumPaths:            3,
+			ConditionNumber:     1.5,
+			IdentifiableFrac:    1.0,
+			UnidentifiableLinks: nil,
+			CoveragePerLink:     []int{2, 3, 1},
+		},
+	}
+	sol := &tomo.Solution{
+		X: mat.NewVecDense(3, []float64{0.5, 15.0, 2.0}),
+	}
+
+	// Capture stdout (printScanTable uses fmt.Printf).
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printScanTable(p, sol, 0, false)
+
+	w.Close()
+	captured, _ := io.ReadAll(r)
+	r.Close()
+	os.Stdout = oldStdout
+
+	out := string(captured)
+	if !strings.Contains(out, "links") {
+		t.Errorf("expected 'links' in table output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Identifiable links") {
+		t.Errorf("expected 'Identifiable links' in table output, got:\n%s", out)
+	}
+}
+
+func TestCLI_PrintScanTableWithTop(t *testing.T) {
+	p := &tomo.Problem{
+		Links: []tomo.Link{
+			{ID: 0, Src: 1, Dst: 2},
+			{ID: 1, Src: 2, Dst: 3},
+			{ID: 2, Src: 3, Dst: 4},
+		},
+		Quality: &tomo.MatrixQuality{
+			Rank:                3,
+			NumLinks:            3,
+			NumPaths:            3,
+			ConditionNumber:     1.5,
+			IdentifiableFrac:    1.0,
+			UnidentifiableLinks: nil,
+			CoveragePerLink:     []int{2, 3, 1},
+		},
+	}
+	sol := &tomo.Solution{
+		X: mat.NewVecDense(3, []float64{0.5, 15.0, 2.0}),
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printScanTable(p, sol, 1, true) // top=1, quiet=true
+
+	w.Close()
+	captured, _ := io.ReadAll(r)
+	r.Close()
+	os.Stdout = oldStdout
+
+	out := string(captured)
+	if out == "" {
+		t.Error("expected non-empty output from printScanTable with top=1")
+	}
+}
+
+func TestCLI_ScanMaxAnonymousInvalid(t *testing.T) {
+	_, err := executeCommand("scan", "--source", "traceroute", "--file", "../../testdata/measurements/ripe_atlas_sample.json", "--max-anonymous", "1.5")
+	if err == nil {
+		t.Fatal("expected error for --max-anonymous > 1")
+	}
+	if !strings.Contains(err.Error(), "max-anonymous") {
+		t.Fatalf("expected error about max-anonymous, got: %v", err)
+	}
+}
+
+func TestCLI_ScanTracerouteNoFile(t *testing.T) {
+	_, err := executeCommand("scan", "--source", "traceroute")
+	if err == nil {
+		t.Fatal("expected error when --source=traceroute without --file")
+	}
+	if !strings.Contains(err.Error(), "--file") {
+		t.Fatalf("expected error about --file, got: %v", err)
+	}
+}
+
+func TestCLI_ScanUnknownFormat(t *testing.T) {
+	_, err := executeCommand("scan", "--source", "traceroute", "--file", "../../testdata/measurements/ripe_atlas_sample.json", "--format", "xml")
+	if err == nil {
+		t.Fatal("expected error for unknown format 'xml'")
+	}
+	if !strings.Contains(err.Error(), "unknown format") {
+		t.Fatalf("expected 'unknown format' error, got: %v", err)
+	}
+}
+
+func TestCLI_CompletionFish(t *testing.T) {
+	out, err := executeCommand("completion", "fish")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("expected non-empty fish completion output")
+	}
+}
+
+func TestCLI_BenchmarkNonexistentDir(t *testing.T) {
+	_, err := executeCommand("benchmark", "-t", "/nonexistent/path/topos")
+	if err == nil {
+		t.Fatal("expected error for nonexistent topology directory")
+	}
+}
+
+func TestCLI_SimulateCustomNoise(t *testing.T) {
+	_, err := executeCommand("simulate", "-t", "../../testdata/topologies/abilene.graphml", "-m", "nnls", "--noise", "0.5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCLI_ScanQuiet(t *testing.T) {
+	out, err := executeCommand("scan", "--source", "traceroute", "--file", "../../testdata/measurements/ripe_atlas_sample.json", "--quiet")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out, "Topology:") {
+		t.Error("expected preamble suppressed with --quiet")
+	}
+}
+
+func TestCLI_ScanWithTikhonov(t *testing.T) {
+	// Exercises the scan path with a non-nnls solver (triggers warnNegativeDelays in context).
+	_, err := executeCommand("scan", "--source", "traceroute", "--file", "../../testdata/measurements/ripe_atlas_sample.json", "-m", "tikhonov")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCLI_PlanHighBudget(t *testing.T) {
+	// With a high budget, should reach full rank and print "all links identifiable".
+	out, err := executeCommand("plan", "-t", "../../testdata/topologies/abilene.graphml", "--budget", "100")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should contain either "all links identifiable" or "Rank deficit"
+	if !strings.Contains(out, "identifiable") && !strings.Contains(out, "Rank deficit") {
+		t.Errorf("expected rank summary in output, got:\n%s", out)
+	}
+}
+
+func TestCLI_BenchmarkCustomFlags(t *testing.T) {
+	out, err := executeCommand("benchmark", "-t", "../../testdata/topologies", "--noise", "0.2", "--congestion-links", "3", "--seed", "99")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Topology") {
+		t.Fatalf("expected output to contain 'Topology', got:\n%s", out)
+	}
+}
+
+func TestCLI_ScanWithMethod(t *testing.T) {
+	// Exercise scan with different solver methods.
+	for _, method := range []string{"tsvd", "admm"} {
+		t.Run(method, func(t *testing.T) {
+			_, err := executeCommand("scan", "--source", "traceroute", "--file", "../../testdata/measurements/ripe_atlas_sample.json", "-m", method)
+			if err != nil {
+				t.Fatalf("unexpected error for method %s: %v", method, err)
+			}
+		})
+	}
+}
+
+func TestCLI_LoadDotEnvSingleQuoted(t *testing.T) {
+	dir := t.TempDir()
+	envContent := "TEST_NETLENS_SQ='single quoted'\n"
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(envContent), 0644); err != nil {
+		t.Fatalf("failed to write .env: %v", err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(origDir)
+		os.Unsetenv("TEST_NETLENS_SQ")
+	}()
+
+	_, _ = executeCommand("version")
+
+	if got := os.Getenv("TEST_NETLENS_SQ"); got != "single quoted" {
+		t.Errorf("expected TEST_NETLENS_SQ='single quoted', got %q", got)
+	}
+}
+
+func TestCLI_BenchmarkGaussianNoise(t *testing.T) {
+	out, err := executeCommand("benchmark", "-t", "../../testdata/topologies", "--noise-model", "gaussian")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Topology") {
+		t.Fatalf("expected output to contain 'Topology', got:\n%s", out)
+	}
+}
+
+func TestCLI_RootNoArgs(t *testing.T) {
+	// Running with no args should show help (exercises the RunE path).
+	out, err := executeCommand()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "netlens") {
+		t.Fatalf("expected help output, got:\n%s", out)
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -411,6 +411,7 @@ func TestCLI_ScanTableFormat(t *testing.T) {
 }
 
 func TestCLI_GetSolverAllValid(t *testing.T) {
+	// Mirrors the switch in getSolver. Also verify unknown name is rejected.
 	names := []string{"tsvd", "tikhonov", "nnls", "admm", "irl1", "vardi", "tomogravity", "laplacian"}
 	for _, name := range names {
 		t.Run(name, func(t *testing.T) {
@@ -423,6 +424,12 @@ func TestCLI_GetSolverAllValid(t *testing.T) {
 			}
 		})
 	}
+	t.Run("unknown", func(t *testing.T) {
+		_, err := getSolver("bogus")
+		if err == nil {
+			t.Fatal("expected error for unknown solver name")
+		}
+	})
 }
 
 func TestCLI_GetSolverEmpty(t *testing.T) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -386,11 +386,9 @@ TEST_NETLENS_QUOTED="hello world"
 	if err := os.Chdir(dir); err != nil {
 		t.Fatalf("failed to chdir: %v", err)
 	}
-	defer func() {
-		_ = os.Chdir(origDir)
-		os.Unsetenv("TEST_NETLENS_FOO")
-		os.Unsetenv("TEST_NETLENS_QUOTED")
-	}()
+	t.Setenv("TEST_NETLENS_FOO", "")
+	t.Setenv("TEST_NETLENS_QUOTED", "")
+	defer func() { _ = os.Chdir(origDir) }()
 
 	_, _ = executeCommand("version")
 
@@ -485,14 +483,17 @@ func TestCLI_PrintScanTable(t *testing.T) {
 
 	// Capture stdout (printScanTable uses fmt.Printf).
 	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
 	os.Stdout = w
 
 	printScanTable(p, sol, 0, false)
 
-	w.Close()
+	_ = w.Close()
 	captured, _ := io.ReadAll(r)
-	r.Close()
+	_ = r.Close()
 	os.Stdout = oldStdout
 
 	out := string(captured)
@@ -526,14 +527,17 @@ func TestCLI_PrintScanTableWithTop(t *testing.T) {
 	}
 
 	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
 	os.Stdout = w
 
 	printScanTable(p, sol, 1, true) // top=1, quiet=true
 
-	w.Close()
+	_ = w.Close()
 	captured, _ := io.ReadAll(r)
-	r.Close()
+	_ = r.Close()
 	os.Stdout = oldStdout
 
 	out := string(captured)
@@ -662,10 +666,8 @@ func TestCLI_LoadDotEnvSingleQuoted(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatalf("failed to chdir: %v", err)
 	}
-	defer func() {
-		_ = os.Chdir(origDir)
-		os.Unsetenv("TEST_NETLENS_SQ")
-	}()
+	t.Setenv("TEST_NETLENS_SQ", "")
+	defer func() { _ = os.Chdir(origDir) }()
 
 	_, _ = executeCommand("version")
 

--- a/internal/measure/httpclient_test.go
+++ b/internal/measure/httpclient_test.go
@@ -1,0 +1,25 @@
+package measure
+
+import "testing"
+
+func TestTruncateBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+		n    int
+		want string
+	}{
+		{"empty", nil, 10, ""},
+		{"short", []byte("hello"), 10, "hello"},
+		{"exact", []byte("hello"), 5, "hello"},
+		{"over", []byte("hello world"), 5, "hello..."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateBody(tt.body, tt.n)
+			if got != tt.want {
+				t.Errorf("truncateBody(%q, %d) = %q, want %q", tt.body, tt.n, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/measure/ripe_test.go
+++ b/internal/measure/ripe_test.go
@@ -345,22 +345,22 @@ func TestParseRetryAfter(t *testing.T) {
 }
 
 func TestPaginatedSearch(t *testing.T) {
-	page := 0
+	var page atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		page++
+		p := int(page.Add(1))
 		w.Header().Set("Content-Type", "application/json")
 
-		item1, _ := json.Marshal(MeasurementInfo{ID: page*10 + 1, Description: "item1"})
-		item2, _ := json.Marshal(MeasurementInfo{ID: page*10 + 2, Description: "item2"})
+		item1, _ := json.Marshal(MeasurementInfo{ID: p*10 + 1, Description: "item1"})
+		item2, _ := json.Marshal(MeasurementInfo{ID: p*10 + 2, Description: "item2"})
 
 		var nextURL string
-		if page == 1 {
+		if p == 1 {
 			nextURL = fmt.Sprintf(`"http://%s/measurements/?page=2"`, r.Host)
 		}
 
 		resp := fmt.Sprintf(`{"count":4,"next":%s,"previous":null,"results":[%s,%s]}`,
 			func() string {
-				if page == 1 {
+				if p == 1 {
 					return nextURL
 				}
 				return "null"

--- a/internal/measure/ripe_test.go
+++ b/internal/measure/ripe_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -406,5 +407,50 @@ func TestSliceIterError(t *testing.T) {
 	}
 	if iter.Err() == nil {
 		t.Error("Err() should return the error")
+	}
+}
+
+func TestWaitForResults_Stopped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/measurements/99/":
+			_, _ = fmt.Fprint(w, `{"id":99,"status":{"id":4,"name":"Stopped"}}`)
+		case "/measurements/99/results/":
+			_, _ = fmt.Fprint(w, mockTracerouteResults)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	src := NewRIPEAtlasSource("test-api-key", srv.URL, srv.Client())
+	ctx := context.Background()
+
+	results, err := src.WaitForResults(ctx, 99, 5*time.Second)
+	if err != nil {
+		t.Fatalf("WaitForResults: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected non-empty results")
+	}
+}
+
+func TestWaitForResults_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":99,"status":{"id":1,"name":"Specified"}}`)
+	}))
+	defer srv.Close()
+
+	src := NewRIPEAtlasSource("test-api-key", srv.URL, srv.Client())
+	ctx := context.Background()
+
+	_, err := src.WaitForResults(ctx, 99, 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("expected error to contain 'timeout', got: %v", err)
 	}
 }

--- a/internal/measure/simulate_unit_test.go
+++ b/internal/measure/simulate_unit_test.go
@@ -1,0 +1,41 @@
+package measure
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func TestAddNoise_ZeroScale(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	got := addNoise(10.0, 0, "lognormal", rng)
+	if got != 10.0 {
+		t.Errorf("expected 10.0 with zero scale, got %f", got)
+	}
+}
+
+func TestAddNoise_Lognormal(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	got := addNoise(10.0, 0.1, "lognormal", rng)
+	if got <= 0 {
+		t.Errorf("lognormal noise should produce positive value, got %f", got)
+	}
+	if got == 10.0 {
+		t.Error("expected noise to change the value")
+	}
+}
+
+func TestAddNoise_Gaussian(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	got := addNoise(10.0, 0.1, "gaussian", rng)
+	if got < 0 {
+		t.Errorf("gaussian noise with clipping should be >= 0, got %f", got)
+	}
+}
+
+func TestAddNoise_NegativeScale(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	got := addNoise(10.0, -1, "lognormal", rng)
+	if got != 10.0 {
+		t.Errorf("negative scale should return original value, got %f", got)
+	}
+}

--- a/internal/measure/simulate_unit_test.go
+++ b/internal/measure/simulate_unit_test.go
@@ -26,7 +26,9 @@ func TestAddNoise_Lognormal(t *testing.T) {
 
 func TestAddNoise_Gaussian(t *testing.T) {
 	rng := rand.New(rand.NewSource(42))
-	got := addNoise(10.0, 0.1, "gaussian", rng)
+	// Use tiny base + large scale so unconstrained noise would go negative;
+	// clipping must prevent that.
+	got := addNoise(0.001, 100.0, "gaussian", rng)
 	if got < 0 {
 		t.Errorf("gaussian noise with clipping should be >= 0, got %f", got)
 	}

--- a/internal/measure/traceroute_file_test.go
+++ b/internal/measure/traceroute_file_test.go
@@ -1,0 +1,31 @@
+package measure
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseScamperFile(t *testing.T) {
+	// Write a minimal scamper JSON to a temp file and parse it
+	data := `[{"type":"trace","src":"1.0.0.1","dst":"2.0.0.1","hops":[{"addr":"1.0.0.1","probe_ttl":1,"rtt":1.5},{"addr":"2.0.0.1","probe_ttl":2,"rtt":5.0}]}]`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.json")
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+	measurements, err := ParseScamperFile(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(measurements) == 0 {
+		t.Fatal("expected at least one measurement")
+	}
+}
+
+func TestParseScamperFile_Nonexistent(t *testing.T) {
+	_, err := ParseScamperFile("/nonexistent/path/file.json")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -715,8 +715,8 @@ func TestRenderTabBar(t *testing.T) {
 
 func TestAllSolvers(t *testing.T) {
 	solvers := allSolvers()
-	if len(solvers) != 8 {
-		t.Errorf("expected 8 solvers, got %d", len(solvers))
+	if len(solvers) == 0 {
+		t.Fatal("expected at least one solver from allSolvers()")
 	}
 	for _, s := range solvers {
 		if s.Name() == "" {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -3,6 +3,8 @@
 package tui
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -525,5 +527,757 @@ func TestModelView_NormalRender(t *testing.T) {
 	}
 	if !strings.Contains(out, "3 links") {
 		t.Error("expected view to contain tree summary")
+	}
+}
+
+// --- NewWizard ---
+
+func TestNewWizard(t *testing.T) {
+	m := NewWizard()
+	if m.phase != phaseSourceSelect {
+		t.Errorf("expected phaseSourceSelect, got %d", m.phase)
+	}
+	if m.expanded == nil {
+		t.Error("expected non-nil expanded map")
+	}
+}
+
+// --- NewWithRefresh ---
+
+func TestNewWithRefresh(t *testing.T) {
+	p, s := testFixture(t)
+	m := NewWithRefresh(p, s, nil, 0, time.Second)
+	if m.refreshRate != time.Second {
+		t.Errorf("expected 1s refresh rate, got %v", m.refreshRate)
+	}
+}
+
+// --- Init ---
+
+func TestModelInit_NoRefresh(t *testing.T) {
+	m := newTestModel(t)
+	cmd := m.Init()
+	if cmd != nil {
+		t.Error("expected nil cmd without refresh rate")
+	}
+}
+
+func TestModelInit_WithRefresh(t *testing.T) {
+	p, s := testFixture(t)
+	solvers := []tomo.Solver{&tomo.TikhonovSolver{}}
+	m := NewWithRefresh(p, s, solvers, 0, 100*time.Millisecond)
+	cmd := m.Init()
+	if cmd == nil {
+		t.Error("expected non-nil cmd with refresh rate and solvers")
+	}
+}
+
+// --- currentSolver ---
+
+func TestCurrentSolver_Empty(t *testing.T) {
+	m := newTestModel(t)
+	if m.currentSolver() != nil {
+		t.Error("expected nil solver with no solvers")
+	}
+}
+
+func TestCurrentSolver_Valid(t *testing.T) {
+	p, s := testFixture(t)
+	solvers := []tomo.Solver{&tomo.TikhonovSolver{}, &tomo.NNLSSolver{}}
+	m := New(p, s, solvers, 1)
+	solver := m.currentSolver()
+	if solver == nil {
+		t.Fatal("expected non-nil solver")
+	}
+	if solver.Name() != "nnls" {
+		t.Errorf("expected nnls solver, got %s", solver.Name())
+	}
+}
+
+// --- nodeLabel ---
+
+func TestNodeLabel_WithLabel(t *testing.T) {
+	p, _ := testFixture(t)
+	label := nodeLabel(p, 0)
+	if label != "A" {
+		t.Errorf("expected 'A', got %q", label)
+	}
+}
+
+func TestNodeLabel_NoMatch(t *testing.T) {
+	p, _ := testFixture(t)
+	label := nodeLabel(p, 999)
+	if label != "node 999" {
+		t.Errorf("expected 'node 999', got %q", label)
+	}
+}
+
+// --- buildGroups ---
+
+func TestBuildGroups(t *testing.T) {
+	p, _ := testFixture(t)
+	groups, order := buildGroups(p)
+	if len(order) != 2 {
+		t.Errorf("expected 2 source nodes, got %d", len(order))
+	}
+	// Node 0 has links 0→1 and 0→2 = 2 links
+	if g, ok := groups[0]; !ok || len(g.links) != 2 {
+		t.Errorf("expected node 0 to have 2 links")
+	}
+	// Node 1 has link 1→2 = 1 link
+	if g, ok := groups[1]; !ok || len(g.links) != 1 {
+		t.Errorf("expected node 1 to have 1 link")
+	}
+}
+
+// --- maxGroupDelay / sumGroupCoverage ---
+
+func TestMaxGroupDelay(t *testing.T) {
+	_, s := testFixture(t)
+	g := &nodeGroup{nodeID: 0, links: []int{0, 2}}
+	// link 0 = 3ms, link 2 = 25ms
+	mx := maxGroupDelay(g, s)
+	if mx != 25.0 {
+		t.Errorf("expected 25.0, got %f", mx)
+	}
+}
+
+func TestSumGroupCoverage(t *testing.T) {
+	p, _ := testFixture(t)
+	g := &nodeGroup{nodeID: 0, links: []int{0, 2}}
+	// coverage: link 0 = 5, link 2 = 8
+	sum := sumGroupCoverage(g, p)
+	if sum != 13 {
+		t.Errorf("expected 13, got %d", sum)
+	}
+}
+
+func TestSumGroupCoverage_NilQuality(t *testing.T) {
+	p, _ := testFixture(t)
+	p.Quality = nil
+	g := &nodeGroup{nodeID: 0, links: []int{0}}
+	if sum := sumGroupCoverage(g, p); sum != 0 {
+		t.Errorf("expected 0 with nil quality, got %d", sum)
+	}
+}
+
+// --- computeOrder ---
+
+func TestComputeOrder_SortNameAlpha(t *testing.T) {
+	p, s := testFixture(t)
+	_, order := computeOrder(p, s, "", SortNameAlpha)
+	if len(order) < 2 {
+		t.Fatal("expected at least 2 groups")
+	}
+	// Node 0 is "A", node 1 is "B" — A should come first
+	if nodeLabel(p, order[0]) > nodeLabel(p, order[1]) {
+		t.Error("expected alphabetical order")
+	}
+}
+
+func TestComputeOrder_Filter(t *testing.T) {
+	p, s := testFixture(t)
+	_, order := computeOrder(p, s, "B", SortDefault)
+	if len(order) != 1 {
+		t.Errorf("expected 1 group matching 'B', got %d", len(order))
+	}
+}
+
+func TestComputeOrder_SortDelayDesc(t *testing.T) {
+	p, s := testFixture(t)
+	_, order := computeOrder(p, s, "", SortDelayDesc)
+	if len(order) < 2 {
+		t.Fatal("expected at least 2 groups")
+	}
+}
+
+func TestComputeOrder_SortCoverageDesc(t *testing.T) {
+	p, s := testFixture(t)
+	_, order := computeOrder(p, s, "", SortCoverageDesc)
+	if len(order) < 2 {
+		t.Fatal("expected at least 2 groups")
+	}
+}
+
+// --- renderTabBar ---
+
+func TestRenderTabBar(t *testing.T) {
+	out := renderTabBar(viewTree, 80)
+	if !strings.Contains(out, "Tree") {
+		t.Error("expected tab bar to contain 'Tree'")
+	}
+	if !strings.Contains(out, "Heatmap") {
+		t.Error("expected tab bar to contain 'Heatmap'")
+	}
+}
+
+// --- allSolvers ---
+
+func TestAllSolvers(t *testing.T) {
+	solvers := allSolvers()
+	if len(solvers) != 8 {
+		t.Errorf("expected 8 solvers, got %d", len(solvers))
+	}
+	for _, s := range solvers {
+		if s.Name() == "" {
+			t.Error("solver has empty name")
+		}
+	}
+}
+
+// --- Wizard phase tests ---
+
+func TestWizardSourceSelect_Navigate(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m = sendKey(m, "j")
+	if m.wizCursor != 1 {
+		t.Errorf("expected wizCursor=1 after j, got %d", m.wizCursor)
+	}
+	m = sendKey(m, "k")
+	if m.wizCursor != 0 {
+		t.Errorf("expected wizCursor=0 after k, got %d", m.wizCursor)
+	}
+}
+
+func TestWizardSourceSelect_EnterSimulate(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	// Select "Simulate" (index 0)
+	m = sendKey(m, "enter")
+	if m.phase != phaseSourceConfig {
+		t.Errorf("expected phaseSourceConfig, got %d", m.phase)
+	}
+	if m.source != sourceSimulate {
+		t.Errorf("expected sourceSimulate, got %d", m.source)
+	}
+}
+
+func TestWizardRenderSourceSelect(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	out := m.View()
+	if !strings.Contains(out, "Simulate") {
+		t.Error("expected source select to contain 'Simulate'")
+	}
+	if !strings.Contains(out, "RIPE Atlas") {
+		t.Error("expected source select to contain 'RIPE Atlas'")
+	}
+}
+
+func TestWizardRenderSolverSelect(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSolverSelect
+	out := m.View()
+	if !strings.Contains(out, "tikhonov") {
+		t.Error("expected solver select to contain 'tikhonov'")
+	}
+	if !strings.Contains(out, "nnls") {
+		t.Error("expected solver select to contain 'nnls'")
+	}
+}
+
+func TestWizardRenderLoading(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseLoading
+	m.loadingMsg = "Loading test..."
+	out := m.View()
+	if !strings.Contains(out, "Loading test") {
+		t.Error("expected loading screen to contain message")
+	}
+}
+
+func TestWizardRenderLoading_Error(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseLoading
+	m.loadErr = "something broke"
+	out := m.View()
+	if !strings.Contains(out, "something broke") {
+		t.Error("expected error message in loading screen")
+	}
+}
+
+// --- loadResultMsg handling ---
+
+func TestUpdateLoading_ResultSuccess(t *testing.T) {
+	p, s := testFixture(t)
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseLoading
+
+	result := loadResultMsg{
+		problem:   p,
+		solution:  s,
+		solvers:   []tomo.Solver{&tomo.TikhonovSolver{}},
+		solverIdx: 0,
+	}
+	updated, _ := m.Update(result)
+	m = updated.(Model)
+	if m.phase != phaseDashboard {
+		t.Errorf("expected phaseDashboard after successful load, got %d", m.phase)
+	}
+	if m.problem != p {
+		t.Error("expected problem to be set")
+	}
+}
+
+func TestUpdateLoading_ResultError(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseLoading
+
+	result := loadResultMsg{err: fmt.Errorf("test error")}
+	updated, _ := m.Update(result)
+	m = updated.(Model)
+	if m.loadErr != "test error" {
+		t.Errorf("expected loadErr='test error', got %q", m.loadErr)
+	}
+}
+
+func TestUpdateLoading_ContextCanceled(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseLoading
+
+	result := loadResultMsg{err: context.Canceled}
+	updated, _ := m.Update(result)
+	m = updated.(Model)
+	if m.loadErr != "" {
+		t.Errorf("expected no loadErr for context.Canceled, got %q", m.loadErr)
+	}
+}
+
+func TestUpdateLoading_SpinnerTick(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseLoading
+	m.spinnerFrame = 0
+
+	updated, cmd := m.Update(spinnerTickMsg{})
+	m = updated.(Model)
+	if m.spinnerFrame != 1 {
+		t.Errorf("expected spinnerFrame=1, got %d", m.spinnerFrame)
+	}
+	if cmd == nil {
+		t.Error("expected non-nil cmd for next spinner tick")
+	}
+}
+
+func TestUpdateLoading_SpinnerStopsOnError(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseLoading
+	m.loadErr = "some error"
+
+	updated, cmd := m.Update(spinnerTickMsg{})
+	m = updated.(Model)
+	if cmd != nil {
+		t.Error("expected nil cmd when loadErr is set")
+	}
+}
+
+func TestUpdateLoading_LogLine(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseLoading
+	ch := make(chan string, 1)
+	m.progCh = ch
+
+	updated, cmd := m.Update(logLineMsg("step 1"))
+	m = updated.(Model)
+	if len(m.loadLogs) != 1 || m.loadLogs[0] != "step 1" {
+		t.Errorf("expected loadLogs=['step 1'], got %v", m.loadLogs)
+	}
+	if cmd == nil {
+		t.Error("expected non-nil cmd to continue listening")
+	}
+}
+
+func TestUpdateLoading_EscOnError(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseLoading
+	m.loadErr = "some error"
+
+	m = sendKey(m, "esc")
+	if m.phase != phaseSolverSelect {
+		t.Errorf("expected phaseSolverSelect after esc on error, got %d", m.phase)
+	}
+	if m.loadErr != "" {
+		t.Errorf("expected loadErr cleared, got %q", m.loadErr)
+	}
+}
+
+func TestUpdateLoading_EscAbort(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseLoading
+	canceled := false
+	m.cancelLoad = func() { canceled = true }
+
+	m = sendKey(m, "esc")
+	if !canceled {
+		t.Error("expected cancelLoad to be called")
+	}
+	if m.phase != phaseSolverSelect {
+		t.Errorf("expected phaseSolverSelect after abort, got %d", m.phase)
+	}
+}
+
+// --- updateSourceConfig ---
+
+func TestWizardSourceConfig_SimulateNavigate(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSourceConfig
+	m.source = sourceSimulate
+
+	m = sendKey(m, "j")
+	if m.wizCursor != 1 {
+		t.Errorf("expected wizCursor=1, got %d", m.wizCursor)
+	}
+	m = sendKey(m, "k")
+	if m.wizCursor != 0 {
+		t.Errorf("expected wizCursor=0, got %d", m.wizCursor)
+	}
+}
+
+func TestWizardSourceConfig_SimulateSelectTopo(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSourceConfig
+	m.source = sourceSimulate
+
+	m = sendKey(m, "enter") // select first bundled topology
+	if m.phase != phaseSolverSelect {
+		t.Errorf("expected phaseSolverSelect, got %d", m.phase)
+	}
+	if m.topoChoice != 0 {
+		t.Errorf("expected topoChoice=0, got %d", m.topoChoice)
+	}
+}
+
+func TestWizardSourceConfig_SimulateEsc(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSourceConfig
+	m.source = sourceSimulate
+
+	m = sendKey(m, "esc")
+	if m.phase != phaseSourceSelect {
+		t.Errorf("expected phaseSourceSelect after esc, got %d", m.phase)
+	}
+}
+
+func TestWizardSourceConfig_SimulateCustomPath(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSourceConfig
+	m.source = sourceSimulate
+	// Navigate to "Custom path..." (last item)
+	m.wizCursor = len(bundledTopologies)
+
+	m = sendKey(m, "enter")
+	if m.source != sourceSimulateCustom {
+		t.Errorf("expected sourceSimulateCustom, got %d", m.source)
+	}
+	if !m.inputActive {
+		t.Error("expected inputActive=true for custom path")
+	}
+}
+
+func TestWizardSourceConfig_RIPEAtlasInput(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSourceConfig
+	m.source = sourceRIPEAtlas
+	m.inputActive = true
+
+	// Type MSM ID
+	m = sendKey(m, "5")
+	m = sendKey(m, "0")
+	m = sendKey(m, "0")
+	m = sendKey(m, "1")
+	if m.msmIDInput != "5001" {
+		t.Errorf("expected msmIDInput='5001', got %q", m.msmIDInput)
+	}
+
+	// Backspace
+	m = sendSpecialKey(m, tea.KeyBackspace)
+	if m.msmIDInput != "500" {
+		t.Errorf("expected msmIDInput='500' after backspace, got %q", m.msmIDInput)
+	}
+
+	// Add back and enter
+	m = sendKey(m, "1")
+	m = sendKey(m, "enter")
+	if m.phase != phaseSolverSelect {
+		t.Errorf("expected phaseSolverSelect after valid MSM ID, got %d", m.phase)
+	}
+}
+
+func TestWizardSourceConfig_RIPEAtlasInvalidID(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSourceConfig
+	m.source = sourceRIPEAtlas
+	m.inputActive = true
+
+	m = sendKey(m, "a")
+	m = sendKey(m, "b")
+	m = sendKey(m, "enter")
+	if m.loadErr == "" {
+		t.Error("expected loadErr for non-numeric MSM ID")
+	}
+	if m.phase != phaseSourceConfig {
+		t.Errorf("expected to stay on phaseSourceConfig, got %d", m.phase)
+	}
+}
+
+func TestWizardSourceConfig_RIPEAtlasEsc(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSourceConfig
+	m.source = sourceRIPEAtlas
+	m.inputActive = true
+	m.msmIDInput = "123"
+
+	m = sendKey(m, "esc")
+	if m.phase != phaseSourceSelect {
+		t.Errorf("expected phaseSourceSelect after esc, got %d", m.phase)
+	}
+	if m.msmIDInput != "" {
+		t.Errorf("expected msmIDInput cleared, got %q", m.msmIDInput)
+	}
+}
+
+func TestWizardSourceConfig_TracerouteEmptyPath(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSourceConfig
+	m.source = sourceTraceroute
+	m.inputActive = true
+
+	m = sendKey(m, "enter")
+	if m.loadErr == "" {
+		t.Error("expected loadErr for empty file path")
+	}
+}
+
+func TestWizardSourceConfig_TracerouteInput(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSourceConfig
+	m.source = sourceTraceroute
+	m.inputActive = true
+
+	m = sendKey(m, "a")
+	if m.filePathInput != "a" {
+		t.Errorf("expected filePathInput='a', got %q", m.filePathInput)
+	}
+	m = sendSpecialKey(m, tea.KeyBackspace)
+	if m.filePathInput != "" {
+		t.Errorf("expected filePathInput empty, got %q", m.filePathInput)
+	}
+}
+
+// --- updateSolverSelect ---
+
+func TestWizardSolverSelect_Navigate(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSolverSelect
+
+	m = sendKey(m, "j")
+	if m.wizCursor != 1 {
+		t.Errorf("expected wizCursor=1, got %d", m.wizCursor)
+	}
+	m = sendKey(m, "k")
+	if m.wizCursor != 0 {
+		t.Errorf("expected wizCursor=0, got %d", m.wizCursor)
+	}
+}
+
+func TestWizardSolverSelect_Esc(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSolverSelect
+	m.source = sourceSimulate
+
+	m = sendKey(m, "esc")
+	if m.phase != phaseSourceConfig {
+		t.Errorf("expected phaseSourceConfig after esc, got %d", m.phase)
+	}
+}
+
+func TestWizardSolverSelect_EscRIPE(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSolverSelect
+	m.source = sourceRIPEAtlas
+
+	m = sendKey(m, "esc")
+	if !m.inputActive {
+		t.Error("expected inputActive=true when going back to RIPE config")
+	}
+}
+
+// --- renderSourceConfig ---
+
+func TestWizardRenderSourceConfig_Simulate(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSourceConfig
+	m.source = sourceSimulate
+	out := m.View()
+	if !strings.Contains(out, "topology") {
+		t.Error("expected source config to mention topology")
+	}
+	if !strings.Contains(out, "abilene") {
+		t.Error("expected bundled topology 'abilene'")
+	}
+}
+
+func TestWizardRenderSourceConfig_RIPEAtlas(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSourceConfig
+	m.source = sourceRIPEAtlas
+	m.inputActive = true
+	out := m.View()
+	if !strings.Contains(out, "Measurement ID") {
+		t.Error("expected RIPE config to contain 'Measurement ID'")
+	}
+}
+
+func TestWizardRenderSourceConfig_Traceroute(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSourceConfig
+	m.source = sourceTraceroute
+	m.inputActive = true
+	out := m.View()
+	if !strings.Contains(out, "File path") {
+		t.Error("expected traceroute config to contain 'File path'")
+	}
+}
+
+func TestWizardRenderSourceConfig_WithError(t *testing.T) {
+	m := NewWizard()
+	m.width = 120
+	m.height = 40
+	m.phase = phaseSourceConfig
+	m.source = sourceRIPEAtlas
+	m.loadErr = "invalid input"
+	out := m.View()
+	if !strings.Contains(out, "invalid input") {
+		t.Error("expected error to appear in source config")
+	}
+}
+
+// --- Dashboard solver switch ---
+
+func TestModelUpdate_SolverSwitch(t *testing.T) {
+	p, s := testFixture(t)
+	solvers := []tomo.Solver{&tomo.TikhonovSolver{}, &tomo.NNLSSolver{}}
+	m := New(p, s, solvers, 0)
+	m.width = 120
+	m.height = 40
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("m")})
+	m = updated.(Model)
+	if m.solverIdx != 1 {
+		t.Errorf("expected solverIdx=1, got %d", m.solverIdx)
+	}
+	if cmd == nil {
+		t.Error("expected non-nil cmd for async re-solve")
+	}
+}
+
+func TestModelUpdate_SolveResult(t *testing.T) {
+	m := newTestModel(t)
+	_, newSol := testFixture(t)
+	updated, _ := m.Update(solveResultMsg{sol: newSol})
+	m = updated.(Model)
+	if m.solution != newSol {
+		t.Error("expected solution to be updated")
+	}
+}
+
+func TestModelUpdate_SolveResultError(t *testing.T) {
+	m := newTestModel(t)
+	updated, _ := m.Update(solveResultMsg{err: fmt.Errorf("solve failed")})
+	m = updated.(Model)
+	if m.solveErr != "solve failed" {
+		t.Errorf("expected solveErr='solve failed', got %q", m.solveErr)
+	}
+}
+
+func TestModelUpdate_TabSwitch(t *testing.T) {
+	m := newTestModel(t)
+	m = sendSpecialKey(m, tea.KeyTab)
+	if m.mode != viewHeatmap {
+		t.Error("expected viewHeatmap after tab")
+	}
+	m = sendSpecialKey(m, tea.KeyTab)
+	if m.mode != viewTree {
+		t.Error("expected viewTree after second tab")
+	}
+}
+
+func TestModelUpdate_EscClosesHelp(t *testing.T) {
+	m := newTestModel(t)
+	m.showHelp = true
+	m = sendKey(m, "esc")
+	if m.showHelp {
+		t.Error("expected showHelp=false after esc")
+	}
+}
+
+func TestModelView_HeatmapMode(t *testing.T) {
+	m := newTestModel(t)
+	m.mode = viewHeatmap
+	out := m.View()
+	if len(out) == 0 {
+		t.Error("expected non-empty heatmap view")
+	}
+}
+
+func TestRenderTabBar_HeatmapActive(t *testing.T) {
+	out := renderTabBar(viewHeatmap, 80)
+	if !strings.Contains(out, "Heatmap") {
+		t.Error("expected tab bar to contain 'Heatmap'")
 	}
 }


### PR DESCRIPTION
## Summary
- **cli**: 68% -> 85% — tests for getSolver, loadDotEnv, printScanTable, warnNegativeDelays, flag combos
- **measure**: 71% -> 78% — tests for ParseScamperFile, truncateBody, WaitForResults, addNoise
- **tui**: 45% -> 75% — tests for wizard phases, tree helpers, tabs, solver switch, loading states

Addresses #107.

## Test plan
- [x] `go test -race ./...` passes
- [x] `go test -race -tags tui ./internal/tui/` passes
- [x] Coverage targets met (cli 85%, tui 75%, measure 78%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)